### PR TITLE
Retain resize listener after closing viewer

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -394,7 +394,6 @@
         });
 
         function closeViewer(viewer) {
-            window.removeEventListener('resize', handleResize);
             if (document.fullscreenElement) document.exitFullscreen();
             if(mainSwiper && mainSwiper.autoplay) mainSwiper.autoplay.stop();
             viewer.style.display = 'none';


### PR DESCRIPTION
## Summary
- keep the resize listener registered when closing the viewer so the slideshow continues to react on reopen

## Testing
- not run (front-end change only)


------
https://chatgpt.com/codex/tasks/task_e_68c847b73f4c832eb0c91991e57e0692