### PR TITLE
Centralize admin template include

### DIFF
--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -9,6 +9,10 @@
 // Sécurité
 if ( ! defined( 'ABSPATH' ) ) exit;
 
+if ( ! defined( 'MGA_ADMIN_TEMPLATE_PATH' ) ) {
+    define( 'MGA_ADMIN_TEMPLATE_PATH', plugin_dir_path( __FILE__ ) . 'includes/admin-page-template.php' );
+}
+
 // ===== FRONT-END =====
 
 /**
@@ -137,8 +141,7 @@ function mga_options_page_html() {
     
     $settings = get_option( 'mga_settings', mga_get_default_settings() );
     
-    $admin_template_path = plugin_dir_path( __FILE__ ) . 'includes/admin-page-template.php';
-    if ( is_readable( $admin_template_path ) ) {
-        include $admin_template_path;
+    if ( is_readable( MGA_ADMIN_TEMPLATE_PATH ) ) {
+        include MGA_ADMIN_TEMPLATE_PATH;
     }
 }


### PR DESCRIPTION
## Summary
- define an `MGA_ADMIN_TEMPLATE_PATH` constant pointing to `includes/admin-page-template.php`
- update `mga_options_page_html` to include the admin template through the centralized constant

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c847af30b0832e9e28d05e3f207ebe