### PR TITLE
Add uninstall cleanup for saved settings

### DIFF
--- a/ma-galerie-automatique/uninstall.php
+++ b/ma-galerie-automatique/uninstall.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Désinstalle le plugin.
+ *
+ * Supprime les options enregistrées.
+ */
+
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+    exit;
+}
+
+delete_option( 'mga_settings' );
+


### PR DESCRIPTION
## Summary
- add an uninstall handler to delete the plugin's saved settings

## Testing
- php -r "define('WP_UNINSTALL_PLUGIN', true); \$deleted = false; function delete_option(\$name) { global \$deleted; if ( 'mga_settings' === \$name ) { \$deleted = true; }} require 'ma-galerie-automatique/uninstall.php'; var_export(\$deleted);"


------
https://chatgpt.com/codex/tasks/task_e_68c85cb93f20832e91ff864d925b0eac