### PR TITLE
Add translations and script i18n support

### DIFF
--- a/ma-galerie-automatique/assets/js/admin-script.js
+++ b/ma-galerie-automatique/assets/js/admin-script.js
@@ -1,3 +1,16 @@
+const mgaAdminI18n = window.wp && window.wp.i18n ? window.wp.i18n : null;
+const mgaAdmin__ = mgaAdminI18n && typeof mgaAdminI18n.__ === 'function' ? mgaAdminI18n.__ : ( text ) => text;
+const mgaAdminSprintf = mgaAdminI18n && typeof mgaAdminI18n.sprintf === 'function'
+    ? mgaAdminI18n.sprintf
+    : ( format, ...args ) => {
+        let index = 0;
+        return format.replace(/%s/g, () => {
+            const replacement = typeof args[index] !== 'undefined' ? args[index] : '';
+            index += 1;
+            return replacement;
+        });
+    };
+
 document.addEventListener('DOMContentLoaded', function() {
     const navTabs = document.querySelectorAll('.mga-admin-wrap .nav-tab');
     const tabContents = document.querySelectorAll('.mga-admin-wrap .tab-content');
@@ -15,7 +28,11 @@ document.addEventListener('DOMContentLoaded', function() {
     // Live update for range sliders
     const thumbSizeSlider = document.getElementById('mga_thumb_size');
     const thumbSizeValue = document.getElementById('mga_thumb_size_value');
-    if(thumbSizeSlider) thumbSizeSlider.addEventListener('input', () => thumbSizeValue.textContent = thumbSizeSlider.value + 'px');
+    if (thumbSizeSlider) {
+        thumbSizeSlider.addEventListener('input', () => {
+            thumbSizeValue.textContent = mgaAdminSprintf(mgaAdmin__('%spx', 'lightbox-jlg'), thumbSizeSlider.value);
+        });
+    }
 
     const opacitySlider = document.getElementById('mga_bg_opacity');
     const opacityValue = document.getElementById('mga_bg_opacity_value');

--- a/ma-galerie-automatique/assets/js/debug.js
+++ b/ma-galerie-automatique/assets/js/debug.js
@@ -1,6 +1,19 @@
 (function(global) {
     "use strict";
 
+    const mgaI18n = global.wp && global.wp.i18n ? global.wp.i18n : null;
+    const mga__ = mgaI18n && typeof mgaI18n.__ === 'function' ? mgaI18n.__ : ( text ) => text;
+    const mgaSprintf = mgaI18n && typeof mgaI18n.sprintf === 'function'
+        ? mgaI18n.sprintf
+        : ( format, ...args ) => {
+            let index = 0;
+            return format.replace(/%s/g, () => {
+                const replacement = typeof args[index] !== 'undefined' ? args[index] : '';
+                index += 1;
+                return replacement;
+            });
+        };
+
     const state = {
         panel: null,
         logContainer: null,
@@ -26,14 +39,14 @@
         panel.id = 'mga-debug-panel';
         panel.style.cssText = 'position: fixed; bottom: 10px; right: 10px; background: #23282d; color: #fff; border: 2px solid #0073aa; padding: 15px; font-family: monospace; font-size: 12px; z-index: 999999; max-width: 450px; box-shadow: 0 5px 15px rgba(0,0,0,0.5);';
         panel.innerHTML = `
-            <h4 style="margin: 0 0 10px; padding: 0 0 10px; border-bottom: 1px solid #444; font-size: 14px;">Debug MGA Performance</h4>
+            <h4 style="margin: 0 0 10px; padding: 0 0 10px; border-bottom: 1px solid #444; font-size: 14px;">${mga__( 'Debug MGA Performance', 'lightbox-jlg' )}</h4>
             <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-bottom: 10px;">
-                <div><strong>Chronomètre réel:</strong><div id="mga-debug-realtime" style="font-size: 16px; color: #4CAF50;">0.00s</div></div>
-                <div><strong>Timer Autoplay:</strong><div id="mga-debug-autoplay-time" style="font-size: 16px; color: #FFC107;">N/A</div></div>
+                <div><strong>${mga__( 'Chronomètre réel :', 'lightbox-jlg' )}</strong><div id="mga-debug-realtime" style="font-size: 16px; color: #4CAF50;">${mgaSprintf( mga__( '%ss', 'lightbox-jlg' ), '0.00' )}</div></div>
+                <div><strong>${mga__( 'Timer Autoplay :', 'lightbox-jlg' )}</strong><div id="mga-debug-autoplay-time" style="font-size: 16px; color: #FFC107;">${mga__( 'N/A', 'lightbox-jlg' )}</div></div>
             </div>
-            <button id="mga-force-open" style="background: #0073aa; color: white; border: none; padding: 8px 12px; cursor: pointer; margin-top: 10px; width: 100%;">Forcer l'ouverture (Test)</button>
+            <button id="mga-force-open" style="background: #0073aa; color: white; border: none; padding: 8px 12px; cursor: pointer; margin-top: 10px; width: 100%;">${mga__( "Forcer l'ouverture (Test)", 'lightbox-jlg' )}</button>
             <div id="mga-log-container" style="margin-top: 15px; max-height: 200px; overflow-y: auto; background: #111; padding: 5px;">
-                 <h5 style="margin:0 0 5px; padding:0; color: #ccc;">Journal d'événements :</h5>
+                 <h5 style="margin:0 0 5px; padding:0; color: #ccc;">${mga__( "Journal d'événements :", 'lightbox-jlg' )}</h5>
                  <div id="mga-debug-log"></div>
             </div>
         `;
@@ -61,7 +74,11 @@
         stopTimer();
         state.startTime = performance.now();
         state.timerInterval = setInterval(() => {
-            updateInfo('mga-debug-realtime', ((performance.now() - state.startTime) / 1000).toFixed(2) + 's', '#4CAF50');
+            updateInfo(
+                'mga-debug-realtime',
+                mgaSprintf(mga__( '%ss', 'lightbox-jlg' ), ((performance.now() - state.startTime) / 1000).toFixed(2)),
+                '#4CAF50'
+            );
         }, 100);
     }
 
@@ -86,14 +103,14 @@
         const time = (performance.now() / 1000).toFixed(3);
         const method = isError ? 'error' : 'log';
         if (typeof console !== 'undefined' && typeof console[method] === 'function') {
-            console[method](`MGA [${time}s]: ${message}`);
+            console[method](mgaSprintf(mga__( 'MGA [%1$ss] : %2$s', 'lightbox-jlg' ), time, message));
         }
         if (!ensureActive() || !state.logContainer) {
             return;
         }
         const entry = document.createElement('p');
         entry.style.cssText = `margin: 2px 5px; padding: 0; color: ${isError ? '#F44336' : '#4CAF50'}; font-size: 11px; word-break: break-all;`;
-        entry.innerHTML = `<span style="color:#888;">[${time}s]</span> > ${message}`;
+        entry.innerHTML = `<span style="color:#888;">${mgaSprintf(mga__( '[%ss]', 'lightbox-jlg' ), time)}</span> > ${message}`;
         state.logContainer.appendChild(entry);
         state.logContainer.scrollTop = state.logContainer.scrollHeight;
     }

--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -1,6 +1,19 @@
 (function() {
     "use strict";
 
+    const mgaI18n = window.wp && window.wp.i18n ? window.wp.i18n : null;
+    const mga__ = mgaI18n && typeof mgaI18n.__ === 'function' ? mgaI18n.__ : ( text ) => text;
+    const mgaSprintf = mgaI18n && typeof mgaI18n.sprintf === 'function'
+        ? mgaI18n.sprintf
+        : ( format, ...args ) => {
+            let index = 0;
+            return format.replace(/%s/g, () => {
+                const replacement = typeof args[index] !== 'undefined' ? args[index] : '';
+                index += 1;
+                return replacement;
+            });
+        };
+
     document.addEventListener('DOMContentLoaded', function() {
         const settings = window.mga_settings || {};
         const noop = () => {};
@@ -69,7 +82,7 @@
         function getViewer() {
             let viewer = document.getElementById('mga-viewer');
             if (!viewer) {
-                debug.log('Viewer non trouvé. Création à la volée...');
+                debug.log(mga__( 'Viewer non trouvé. Création à la volée...', 'lightbox-jlg' ));
                 const viewerHTML = `
                     <div id="mga-viewer" class="mga-viewer" style="display: none;" role="dialog" aria-modal="true">
                         <div class="mga-echo-bg"></div>
@@ -78,14 +91,14 @@
                             <div id="mga-counter" class="mga-counter"></div>
                             <div class="mga-caption-container"><p id="mga-caption" class="mga-caption"></p></div>
                             <div class="mga-toolbar">
-                                <button id="mga-play-pause" class="mga-toolbar-button" aria-label="Play/Pause">
+                                <button id="mga-play-pause" class="mga-toolbar-button" aria-label="${mga__( 'Play/Pause', 'lightbox-jlg' )}">
                                     <svg class="mga-timer-svg" viewBox="0 0 36 36"><path class="mga-timer-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831" /><path class="mga-timer-progress" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831" /></svg>
                                     <svg class="mga-icon mga-play-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>
                                     <svg class="mga-icon mga-pause-icon" style="display:none;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/></svg>
                                 </button>
-                                <button id="mga-zoom" class="mga-toolbar-button" aria-label="Zoom"><svg class="mga-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M10 9h-1v-1H8v1H7v1h1v1h1v-1h1V9z"/></svg></button>
-                                <button id="mga-fullscreen" class="mga-toolbar-button" aria-label="Fullscreen"><svg class="mga-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5V14h-2v3zM14 5v2h3v3h2V5h-5z"/></svg></button>
-                                <button id="mga-close" class="mga-toolbar-button" aria-label="Close"><svg class="mga-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg></button>
+                                <button id="mga-zoom" class="mga-toolbar-button" aria-label="${mga__( 'Zoom', 'lightbox-jlg' )}"><svg class="mga-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M10 9h-1v-1H8v1H7v1h1v1h1v-1h1V9z"/></svg></button>
+                                <button id="mga-fullscreen" class="mga-toolbar-button" aria-label="${mga__( 'Plein écran', 'lightbox-jlg' )}"><svg class="mga-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5V14h-2v3zM14 5v2h3v3h2V5h-5z"/></svg></button>
+                                <button id="mga-close" class="mga-toolbar-button" aria-label="${mga__( 'Fermer', 'lightbox-jlg' )}"><svg class="mga-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg></button>
                             </div>
                         </div>
 
@@ -94,19 +107,19 @@
                     </div>`;
                 document.body.insertAdjacentHTML('beforeend', viewerHTML);
                 viewer = document.getElementById('mga-viewer');
-                if (viewer) debug.log('Viewer créé et ajouté au body avec succès.');
-                else debug.log('ERREUR CRITIQUE: Échec de la création du viewer !', true);
+                if (viewer) debug.log(mga__( 'Viewer créé et ajouté au body avec succès.', 'lightbox-jlg' ));
+                else debug.log(mga__( 'ERREUR CRITIQUE : Échec de la création du viewer !', 'lightbox-jlg' ), true);
             }
             return viewer;
         }
 
         // --- LOGIQUE PRINCIPALE ---
-        debug.log('Script initialisé et prêt.');
-        debug.updateInfo('mga-debug-status', 'Prêt', '#4CAF50');
+        debug.log(mga__( 'Script initialisé et prêt.', 'lightbox-jlg' ));
+        debug.updateInfo('mga-debug-status', mga__( 'Prêt', 'lightbox-jlg' ), '#4CAF50');
 
         const contentSelectors = ['.wp-block-post-content', '.entry-content', '.post-content'];
         let contentArea = document.body;
-        let foundSelector = '<body> (fallback)';
+        let foundSelector = mga__( '<body> (fallback)', 'lightbox-jlg' );
         for (const selector of contentSelectors) {
             const area = document.querySelector(selector);
             if (area) {
@@ -121,10 +134,10 @@
         debug.updateInfo('mga-debug-trigger-img', triggerLinks.length);
 
         debug.onForceOpen(() => {
-            debug.log("Clic sur 'Forcer l'ouverture'.");
+            debug.log(mga__( "Clic sur 'Forcer l'ouverture'.", 'lightbox-jlg' ));
             const testImages = [
-                { highResUrl: 'https://placehold.co/800x600/0073aa/ffffff?text=Image+Test+1', thumbUrl: 'https://placehold.co/150x150/0073aa/ffffff?text=Thumb+1', caption: 'Ceci est la première image de test.' },
-                { highResUrl: 'https://placehold.co/800x600/F44336/ffffff?text=Image+Test+2', thumbUrl: 'https://placehold.co/150x150/F44336/ffffff?text=Thumb+2', caption: 'Ceci est la seconde image de test.' }
+                { highResUrl: 'https://placehold.co/800x600/0073aa/ffffff?text=Image+Test+1', thumbUrl: 'https://placehold.co/150x150/0073aa/ffffff?text=Thumb+1', caption: mga__( 'Ceci est la première image de test.', 'lightbox-jlg' ) },
+                { highResUrl: 'https://placehold.co/800x600/F44336/ffffff?text=Image+Test+2', thumbUrl: 'https://placehold.co/150x150/F44336/ffffff?text=Thumb+2', caption: mga__( 'Ceci est la seconde image de test.', 'lightbox-jlg' ) }
             ];
             openViewer(testImages, 0);
         });
@@ -132,7 +145,7 @@
         contentArea.addEventListener('click', function (e) {
             const targetLink = e.target.closest('a');
             if (targetLink && targetLink.querySelector('img')) {
-                debug.log("Clic sur un lien contenant une image.");
+                debug.log(mga__( 'Clic sur un lien contenant une image.', 'lightbox-jlg' ));
                 e.preventDefault();
                 e.stopPropagation();
 
@@ -156,7 +169,7 @@
                     return { highResUrl, thumbUrl, caption };
                 }).filter(item => item && item.highResUrl);
                 
-                debug.log(`${galleryData.length} images valides préparées pour la galerie.`);
+                debug.log(mgaSprintf(mga__( '%d images valides préparées pour la galerie.', 'lightbox-jlg' ), galleryData.length));
                 debug.table(galleryData);
 
                 const clickedHighResUrl = getHighResUrl(targetLink);
@@ -165,14 +178,14 @@
                 if (startIndex !== -1) {
                     openViewer(galleryData, startIndex);
                 } else {
-                    debug.log("ERREUR: L'image cliquée n'a pas été trouvée dans la galerie construite.", true);
-                    debug.log(`URL cliquée cherchée : ${clickedHighResUrl}`, true);
+                    debug.log(mga__( "ERREUR : L'image cliquée n'a pas été trouvée dans la galerie construite.", 'lightbox-jlg' ), true);
+                    debug.log(mgaSprintf(mga__( 'URL cliquée recherchée : %s', 'lightbox-jlg' ), clickedHighResUrl), true);
                 }
             }
         }, true);
 
         function openViewer(images, startIndex) {
-            debug.log(`openViewer appelé avec ${images.length} images, index ${startIndex}.`);
+            debug.log(mgaSprintf(mga__( 'openViewer appelé avec %1$d images, index %2$d.', 'lightbox-jlg' ), images.length, startIndex));
             const viewer = getViewer();
             if (!viewer) return;
 
@@ -223,17 +236,17 @@
 
                     thumbsWrapper.appendChild(thumbSlide);
                 });
-                debug.log('Wrappers HTML remplis avec URLs optimisées.');
+                debug.log(mga__( 'Wrappers HTML remplis avec URLs optimisées.', 'lightbox-jlg' ));
 
                 initSwiper(viewer, images);
                 mainSwiper.slideToLoop(startIndex, 0);
                 updateInfo(viewer, images, startIndex);
                 viewer.style.display = 'flex';
                 document.body.style.overflow = 'hidden';
-                debug.log('Galerie affichée avec succès.');
+                debug.log(mga__( 'Galerie affichée avec succès.', 'lightbox-jlg' ));
                 window.addEventListener('resize', handleResize);
             } catch (error) {
-                debug.log(`ERREUR dans openViewer: ${error.message}`, true);
+                debug.log(mgaSprintf(mga__( 'ERREUR dans openViewer : %s', 'lightbox-jlg' ), error.message), true);
                 console.error(error);
             }
         }
@@ -280,24 +293,24 @@
                     autoplayTimeLeft(s, time, progress) {
                         const progressCircle = viewer.querySelector('.mga-timer-progress');
                         if (progressCircle) progressCircle.style.strokeDashoffset = 100 - (progress * 100);
-                        debug.updateInfo('mga-debug-autoplay-time', (time / 1000).toFixed(2) + 's');
+                        debug.updateInfo('mga-debug-autoplay-time', mgaSprintf(mga__( '%ss', 'lightbox-jlg' ), (time / 1000).toFixed(2)));
                     },
                     slideChangeTransitionStart: function(swiper) {
                         const slide = swiper.slides[swiper.activeIndex];
                         const img = slide.querySelector('img');
                         if (img && !img.complete) {
-                            debug.log(`Chargement de l'image ${slide.dataset.slideIndex}...`);
+                            debug.log(mgaSprintf(mga__( "Chargement de l'image %s...", 'lightbox-jlg' ), slide.dataset.slideIndex));
                             slide.querySelector('.mga-spinner').style.display = 'block';
                             img.onload = () => {
-                                debug.log(`Image ${slide.dataset.slideIndex} chargée.`);
+                                debug.log(mgaSprintf(mga__( 'Image %s chargée.', 'lightbox-jlg' ), slide.dataset.slideIndex));
                                 slide.querySelector('.mga-spinner').style.display = 'none';
                             };
                         }
                     },
-                    autoplayStart: () => { debug.log('Autoplay DÉMARRÉ.'); viewer.querySelector('.mga-play-icon').style.display = 'none'; viewer.querySelector('.mga-pause-icon').style.display = 'inline-block'; },
-                    autoplayStop: () => { debug.log('Autoplay ARRÊTÉ.'); viewer.querySelector('.mga-play-icon').style.display = 'inline-block'; viewer.querySelector('.mga-pause-icon').style.display = 'none'; const progressCircle = viewer.querySelector('.mga-timer-progress'); if (progressCircle) progressCircle.style.strokeDashoffset = 100; debug.updateInfo('mga-debug-autoplay-time', 'Stoppé'); },
-                    touchStart: () => { debug.log('Interaction manuelle DÉTECTÉE (touch).'); },
-                    sliderMove: () => { debug.log('Interaction manuelle DÉTECTÉE (drag).'); }
+                    autoplayStart: () => { debug.log(mga__( 'Autoplay DÉMARRÉ.', 'lightbox-jlg' )); viewer.querySelector('.mga-play-icon').style.display = 'none'; viewer.querySelector('.mga-pause-icon').style.display = 'inline-block'; },
+                    autoplayStop: () => { debug.log(mga__( 'Autoplay ARRÊTÉ.', 'lightbox-jlg' )); viewer.querySelector('.mga-play-icon').style.display = 'inline-block'; viewer.querySelector('.mga-pause-icon').style.display = 'none'; const progressCircle = viewer.querySelector('.mga-timer-progress'); if (progressCircle) progressCircle.style.strokeDashoffset = 100; debug.updateInfo('mga-debug-autoplay-time', mga__( 'Stoppé', 'lightbox-jlg' )); },
+                    touchStart: () => { debug.log(mga__( 'Interaction manuelle DÉTECTÉE (touch).', 'lightbox-jlg' )); },
+                    sliderMove: () => { debug.log(mga__( 'Interaction manuelle DÉTECTÉE (drag).', 'lightbox-jlg' )); }
                 },
             });
 
@@ -315,7 +328,7 @@
             [nextIndex, prevIndex].forEach(index => {
                 const imageUrl = images[index]?.highResUrl;
                 if (imageUrl && !preloadedUrls.has(imageUrl)) {
-                    debug.log(`Préchargement de l'image ${index}`);
+                    debug.log(mgaSprintf(mga__( "Préchargement de l'image %s", 'lightbox-jlg' ), index));
                     const img = new Image();
                     img.src = imageUrl;
                     preloadedUrls.add(imageUrl);
@@ -344,7 +357,7 @@
             if (images[index]) {
                 viewer.querySelector('#mga-caption').textContent = images[index].caption;
                 viewer.querySelector('.mga-caption-container').style.visibility = images[index].caption ? 'visible' : 'hidden';
-                viewer.querySelector('#mga-counter').textContent = `${index + 1} / ${images.length}`;
+                viewer.querySelector('#mga-counter').textContent = mgaSprintf(mga__( '%1$s / %2$s', 'lightbox-jlg' ), index + 1, images.length);
             }
         }
 
@@ -354,7 +367,7 @@
             if (e.target.closest('#mga-close')) closeViewer(viewer);
             if (e.target.closest('#mga-play-pause')) { if (mainSwiper && mainSwiper.autoplay && mainSwiper.autoplay.running) mainSwiper.autoplay.stop(); else if (mainSwiper && mainSwiper.autoplay) mainSwiper.autoplay.start(); }
             if (e.target.closest('#mga-zoom')) { if (mainSwiper && mainSwiper.zoom) mainSwiper.zoom.toggle(); }
-            if (e.target.closest('#mga-fullscreen')) { if (!document.fullscreenElement) viewer.requestFullscreen().catch(err => debug.log('Erreur plein écran: ' + err.message, true)); else document.exitFullscreen(); }
+            if (e.target.closest('#mga-fullscreen')) { if (!document.fullscreenElement) viewer.requestFullscreen().catch(err => debug.log(mgaSprintf(mga__( 'Erreur plein écran : %s', 'lightbox-jlg' ), err.message), true)); else document.exitFullscreen(); }
         });
         
         document.addEventListener('keydown', (e) => { 
@@ -372,7 +385,7 @@
             if(mainSwiper && mainSwiper.autoplay) mainSwiper.autoplay.stop();
             viewer.style.display = 'none';
             document.body.style.overflow = '';
-            debug.log('Galerie fermée.');
+            debug.log(mga__( 'Galerie fermée.', 'lightbox-jlg' ));
             debug.stopTimer();
         }
 
@@ -381,12 +394,12 @@
             resizeTimeout = setTimeout(() => {
                 if (mainSwiper && mainSwiper.el && !mainSwiper.destroyed) {
                     const wasRunning = mainSwiper.autoplay.running;
-                    debug.log('Redimensionnement détecté. Mise à jour de Swiper.');
+                    debug.log(mga__( 'Redimensionnement détecté. Mise à jour de Swiper.', 'lightbox-jlg' ));
                     mainSwiper.update();
                     if(thumbsSwiper && !thumbsSwiper.destroyed) thumbsSwiper.update();
                     if (wasRunning) {
                         mainSwiper.autoplay.start();
-                        debug.log('Autoplay relancé après redimensionnement.');
+                        debug.log(mga__( 'Autoplay relancé après redimensionnement.', 'lightbox-jlg' ));
                     }
                 }
             }, 250);

--- a/ma-galerie-automatique/includes/admin-page-template.php
+++ b/ma-galerie-automatique/includes/admin-page-template.php
@@ -12,97 +12,97 @@ $settings = wp_parse_args( $settings, $defaults );
 ?>
 <div class="wrap mga-admin-wrap">
     <h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
-    
+
     <div class="nav-tab-wrapper">
-        <a href="#settings" class="nav-tab nav-tab-active">Réglages</a>
-        <a href="#tutorial" class="nav-tab">Tutoriel</a>
+        <a href="#settings" class="nav-tab nav-tab-active"><?php echo esc_html__( 'Réglages', 'lightbox-jlg' ); ?></a>
+        <a href="#tutorial" class="nav-tab"><?php echo esc_html__( 'Tutoriel', 'lightbox-jlg' ); ?></a>
     </div>
 
     <form action="options.php" method="post">
         <?php settings_fields( 'mga_settings_group' ); ?>
-        
+
         <div id="settings" class="tab-content active">
             <table class="form-table">
                 <tr>
-                    <th scope="row"><label for="mga_delay">Vitesse du diaporama</label></th>
+                    <th scope="row"><label for="mga_delay"><?php echo esc_html__( 'Vitesse du diaporama', 'lightbox-jlg' ); ?></label></th>
                     <td>
-                        <input name="mga_settings[delay]" type="number" id="mga_delay" value="<?php echo esc_attr($settings['delay']); ?>" min="1" max="30" class="small-text" /> secondes
-                        <p class="description">Durée d'affichage de chaque image en mode lecture automatique.</p>
+                        <input name="mga_settings[delay]" type="number" id="mga_delay" value="<?php echo esc_attr( $settings['delay'] ); ?>" min="1" max="30" class="small-text" /> <?php echo esc_html__( 'secondes', 'lightbox-jlg' ); ?>
+                        <p class="description"><?php echo esc_html__( "Durée d'affichage de chaque image en mode lecture automatique.", 'lightbox-jlg' ); ?></p>
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row">Taille des miniatures</th>
+                    <th scope="row"><?php echo esc_html__( 'Taille des miniatures', 'lightbox-jlg' ); ?></th>
                     <td>
-                        <label for="mga_thumb_size">PC</label><br>
-                        <input name="mga_settings[thumb_size]" type="range" id="mga_thumb_size" value="<?php echo esc_attr($settings['thumb_size']); ?>" min="50" max="150" step="5" />
-                        <span id="mga_thumb_size_value"><?php echo esc_attr($settings['thumb_size']); ?>px</span>
+                        <label for="mga_thumb_size"><?php echo esc_html__( 'PC', 'lightbox-jlg' ); ?></label><br>
+                        <input name="mga_settings[thumb_size]" type="range" id="mga_thumb_size" value="<?php echo esc_attr( $settings['thumb_size'] ); ?>" min="50" max="150" step="5" />
+                        <span id="mga_thumb_size_value"><?php printf( esc_html__( '%dpx', 'lightbox-jlg' ), intval( $settings['thumb_size'] ) ); ?></span>
                         <br><br>
-                        <label for="mga_thumb_size_mobile">Mobile</label><br>
-                        <input name="mga_settings[thumb_size_mobile]" type="range" id="mga_thumb_size_mobile" value="<?php echo esc_attr($settings['thumb_size_mobile']); ?>" min="40" max="100" step="5" />
-                        <span id="mga_thumb_size_mobile_value"><?php echo esc_attr($settings['thumb_size_mobile']); ?>px</span>
-                        <p class="description">Ajustez la hauteur des miniatures en bas de la galerie pour chaque type d'appareil.</p>
+                        <label for="mga_thumb_size_mobile"><?php echo esc_html__( 'Mobile', 'lightbox-jlg' ); ?></label><br>
+                        <input name="mga_settings[thumb_size_mobile]" type="range" id="mga_thumb_size_mobile" value="<?php echo esc_attr( $settings['thumb_size_mobile'] ); ?>" min="40" max="100" step="5" />
+                        <span id="mga_thumb_size_mobile_value"><?php printf( esc_html__( '%dpx', 'lightbox-jlg' ), intval( $settings['thumb_size_mobile'] ) ); ?></span>
+                        <p class="description"><?php echo esc_html__( "Ajustez la hauteur des miniatures en bas de la galerie pour chaque type d'appareil.", 'lightbox-jlg' ); ?></p>
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row"><label for="mga_accent_color">Couleur d'accentuation</label></th>
+                    <th scope="row"><label for="mga_accent_color"><?php echo esc_html__( "Couleur d'accentuation", 'lightbox-jlg' ); ?></label></th>
                     <td>
-                        <input name="mga_settings[accent_color]" type="color" id="mga_accent_color" value="<?php echo esc_attr($settings['accent_color']); ?>" />
-                        <p class="description">Couleur des boutons, flèches et de la bordure de la miniature active.</p>
+                        <input name="mga_settings[accent_color]" type="color" id="mga_accent_color" value="<?php echo esc_attr( $settings['accent_color'] ); ?>" />
+                        <p class="description"><?php echo esc_html__( 'Couleur des boutons, flèches et de la bordure de la miniature active.', 'lightbox-jlg' ); ?></p>
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row"><label for="mga_bg_opacity">Opacité de l'arrière-plan</label></th>
+                    <th scope="row"><label for="mga_bg_opacity"><?php echo esc_html__( "Opacité de l'arrière-plan", 'lightbox-jlg' ); ?></label></th>
                     <td>
-                         <input name="mga_settings[bg_opacity]" type="range" id="mga_bg_opacity" value="<?php echo esc_attr($settings['bg_opacity']); ?>" min="0.5" max="1" step="0.05" />
-                         <span id="mga_bg_opacity_value"><?php echo esc_attr($settings['bg_opacity']); ?></span>
-                        <p class="description">Réglez la transparence du fond de la galerie (0.5 = transparent, 1 = opaque).</p>
+                         <input name="mga_settings[bg_opacity]" type="range" id="mga_bg_opacity" value="<?php echo esc_attr( $settings['bg_opacity'] ); ?>" min="0.5" max="1" step="0.05" />
+                         <span id="mga_bg_opacity_value"><?php echo esc_html( $settings['bg_opacity'] ); ?></span>
+                        <p class="description"><?php echo esc_html__( "Réglez la transparence du fond de la galerie (0.5 = transparent, 1 = opaque).", 'lightbox-jlg' ); ?></p>
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row"><label for="mga_background_style">Effet d'arrière-plan</label></th>
+                    <th scope="row"><label for="mga_background_style"><?php echo esc_html__( "Effet d'arrière-plan", 'lightbox-jlg' ); ?></label></th>
                     <td>
                         <select name="mga_settings[background_style]" id="mga_background_style">
-                            <option value="echo" <?php selected($settings['background_style'], 'echo'); ?>>Flou d'écho d'image (Recommandé)</option>
-                            <option value="texture" <?php selected($settings['background_style'], 'texture'); ?>>Texture verre dépoli (Performance max)</option>
-                            <option value="blur" <?php selected($settings['background_style'], 'blur'); ?>>Flou en temps réel (Gourmand)</option>
+                            <option value="echo" <?php selected( $settings['background_style'], 'echo' ); ?>><?php echo esc_html__( "Flou d'écho d'image (Recommandé)", 'lightbox-jlg' ); ?></option>
+                            <option value="texture" <?php selected( $settings['background_style'], 'texture' ); ?>><?php echo esc_html__( 'Texture verre dépoli (Performance max)', 'lightbox-jlg' ); ?></option>
+                            <option value="blur" <?php selected( $settings['background_style'], 'blur' ); ?>><?php echo esc_html__( 'Flou en temps réel (Gourmand)', 'lightbox-jlg' ); ?></option>
                         </select>
-                        <p class="description">Choisissez le style de l'arrière-plan pour un compromis entre design et performance.</p>
+                        <p class="description"><?php echo esc_html__( "Choisissez le style de l'arrière-plan pour un compromis entre design et performance.", 'lightbox-jlg' ); ?></p>
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row"><label for="mga_z_index">Z-index de la galerie</label></th>
+                    <th scope="row"><label for="mga_z_index"><?php echo esc_html__( 'Z-index de la galerie', 'lightbox-jlg' ); ?></label></th>
                     <td>
-                        <input name="mga_settings[z_index]" type="number" id="mga_z_index" value="<?php echo esc_attr($settings['z_index']); ?>" min="1" class="small-text" />
-                        <p class="description">Augmentez cette valeur si la galerie apparaît sous un autre élément (ex: menu du site).</p>
+                        <input name="mga_settings[z_index]" type="number" id="mga_z_index" value="<?php echo esc_attr( $settings['z_index'] ); ?>" min="1" class="small-text" />
+                        <p class="description"><?php echo esc_html__( "Augmentez cette valeur si la galerie apparaît sous un autre élément (ex: menu du site).", 'lightbox-jlg' ); ?></p>
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row">Options diverses</th>
+                    <th scope="row"><?php echo esc_html__( 'Options diverses', 'lightbox-jlg' ); ?></th>
                     <td>
                         <fieldset>
                             <label for="mga_loop">
-                                <input name="mga_settings[loop]" type="checkbox" id="mga_loop" value="1" <?php checked( !empty($settings['loop']), 1 ); ?> />
-                                <span>Lecture en boucle</span>
+                                <input name="mga_settings[loop]" type="checkbox" id="mga_loop" value="1" <?php checked( ! empty( $settings['loop'] ), 1 ); ?> />
+                                <span><?php echo esc_html__( 'Lecture en boucle', 'lightbox-jlg' ); ?></span>
                             </label>
-                            <p class="description">Permet au diaporama de recommencer au début après la dernière image.</p>
+                            <p class="description"><?php echo esc_html__( 'Permet au diaporama de recommencer au début après la dernière image.', 'lightbox-jlg' ); ?></p>
                             <br>
                             <label for="mga_autoplay_start">
-                                <input name="mga_settings[autoplay_start]" type="checkbox" id="mga_autoplay_start" value="1" <?php checked( !empty($settings['autoplay_start']), 1 ); ?> />
-                                <span>Lancement auto. du diaporama</span>
+                                <input name="mga_settings[autoplay_start]" type="checkbox" id="mga_autoplay_start" value="1" <?php checked( ! empty( $settings['autoplay_start'] ), 1 ); ?> />
+                                <span><?php echo esc_html__( 'Lancement auto. du diaporama', 'lightbox-jlg' ); ?></span>
                             </label>
-                            <p class="description">Si coché, le diaporama démarre automatiquement à l'ouverture de la galerie.</p>
+                            <p class="description"><?php echo esc_html__( "Si coché, le diaporama démarre automatiquement à l'ouverture de la galerie.", 'lightbox-jlg' ); ?></p>
                         </fieldset>
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row">Mode de débogage</th>
+                    <th scope="row"><?php echo esc_html__( 'Mode de débogage', 'lightbox-jlg' ); ?></th>
                     <td>
                         <fieldset>
                             <label for="mga_debug_mode">
-                                <input name="mga_settings[debug_mode]" type="checkbox" id="mga_debug_mode" value="1" <?php checked( !empty($settings['debug_mode']), 1 ); ?> />
-                                <span>Activer le mode débogage</span>
+                                <input name="mga_settings[debug_mode]" type="checkbox" id="mga_debug_mode" value="1" <?php checked( ! empty( $settings['debug_mode'] ), 1 ); ?> />
+                                <span><?php echo esc_html__( 'Activer le mode débogage', 'lightbox-jlg' ); ?></span>
                             </label>
-                            <p class="description">Affiche un panneau d'informations techniques sur le site pour aider à résoudre les problèmes.</p>
+                            <p class="description"><?php echo esc_html__( "Affiche un panneau d'informations techniques sur le site pour aider à résoudre les problèmes.", 'lightbox-jlg' ); ?></p>
                         </fieldset>
                     </td>
                 </tr>
@@ -110,22 +110,22 @@ $settings = wp_parse_args( $settings, $defaults );
         </div>
 
         <div id="tutorial" class="tab-content">
-            <h2><span class="dashicons dashicons-editor-help"></span> Comment faire fonctionner la galerie ?</h2>
-            <p>Cette extension est conçue pour s'intégrer naturellement à WordPress. Le principe est simple : seules les images que vous décidez de lier deviendront des déclencheurs pour la galerie.</p>
+            <h2><span class="dashicons dashicons-editor-help"></span> <?php echo esc_html__( 'Comment faire fonctionner la galerie ?', 'lightbox-jlg' ); ?></h2>
+            <p><?php echo esc_html__( "Cette extension est conçue pour s'intégrer naturellement à WordPress. Le principe est simple : seules les images que vous décidez de lier deviendront des déclencheurs pour la galerie.", 'lightbox-jlg' ); ?></p>
             <ol style="list-style-type: decimal; margin-left: 20px;">
-                <li><strong>Éditez un article ou une page :</strong> Allez dans l'éditeur de blocs de WordPress.</li>
-                <li><strong>Sélectionnez une image :</strong> Cliquez sur un bloc image que vous souhaitez inclure dans la galerie.</li>
-                <li><strong>Activez le lien :</strong> Dans la barre d'outils du bloc image, cliquez sur l'icône de lien (ressemble à un maillon de chaîne).</li>
-                <li style="margin-top: 10px;"><strong>Choisissez la bonne destination :</strong> Une petite fenêtre apparaît. Cliquez sur l'option <strong>"Fichier média"</strong>. C'est l'étape la plus importante ! Elle indique que le clic sur l'image doit ouvrir le fichier image original.</li>
-                <li style="margin-top: 10px;"><strong>Répétez pour d'autres images :</strong> Faites de même pour toutes les images de l'article que vous voulez voir apparaître dans la même galerie.</li>
+                <li><?php echo wp_kses_post( __( "<strong>Éditez un article ou une page :</strong> Allez dans l'éditeur de blocs de WordPress.", 'lightbox-jlg' ) ); ?></li>
+                <li><?php echo wp_kses_post( __( '<strong>Sélectionnez une image :</strong> Cliquez sur un bloc image que vous souhaitez inclure dans la galerie.', 'lightbox-jlg' ) ); ?></li>
+                <li><?php echo wp_kses_post( __( "<strong>Activez le lien :</strong> Dans la barre d'outils du bloc image, cliquez sur l'icône de lien (ressemble à un maillon de chaîne).", 'lightbox-jlg' ) ); ?></li>
+                <li style="margin-top: 10px;"><?php echo wp_kses_post( __( '<strong>Choisissez la bonne destination :</strong> Une petite fenêtre apparaît. Cliquez sur l’option <strong>&quot;Fichier média&quot;</strong>. C’est l’étape la plus importante ! Elle indique que le clic sur l’image doit ouvrir le fichier image original.', 'lightbox-jlg' ) ); ?></li>
+                <li style="margin-top: 10px;"><?php echo wp_kses_post( __( "<strong>Répétez pour d'autres images :</strong> Faites de même pour toutes les images de l'article que vous voulez voir apparaître dans la même galerie.", 'lightbox-jlg' ) ); ?></li>
             </ol>
-            <h3>C'est tout !</h3>
-            <p>Désormais, sur votre site, lorsque qu'un visiteur cliquera sur l'une de ces images, la visionneuse (lightbox) s'ouvrira et affichera toutes les autres images de l'article qui ont également été liées à leur "Fichier média".</p>
-            
-            <h4>Astuce pour les légendes</h4>
-            <p>La légende affichée dans la galerie est récupérée automatiquement depuis le champ <strong>"Légende"</strong> de votre image dans l'éditeur, ou, si celui-ci est vide, depuis le champ <strong>"Texte alternatif"</strong>. Pensez à les remplir !</p>
+            <h3><?php echo esc_html__( "C'est tout !", 'lightbox-jlg' ); ?></h3>
+            <p><?php echo esc_html__( "Désormais, sur votre site, lorsque qu'un visiteur cliquera sur l'une de ces images, la visionneuse (lightbox) s'ouvrira et affichera toutes les autres images de l'article qui ont également été liées à leur &quot;Fichier média&quot;.", 'lightbox-jlg' ); ?></p>
+
+            <h4><?php echo esc_html__( 'Astuce pour les légendes', 'lightbox-jlg' ); ?></h4>
+            <p><?php echo wp_kses_post( __( 'La légende affichée dans la galerie est récupérée automatiquement depuis le champ <strong>&quot;Légende&quot;</strong> de votre image dans l’éditeur, ou, si celui-ci est vide, depuis le champ <strong>&quot;Texte alternatif&quot;</strong>. Pensez à les remplir !', 'lightbox-jlg' ) ); ?></p>
         </div>
 
-        <?php submit_button( 'Enregistrer les modifications' ); ?>
+        <?php submit_button( __( 'Enregistrer les modifications', 'lightbox-jlg' ) ); ?>
     </form>
 </div>

--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -4,6 +4,8 @@
  * Description:       Transforme les galeries d'images en un slideshow plein écran avec de nombreuses options de personnalisation.
  * Version:           1.8
  * Author:            Jérôme Le Gousse
+ * Text Domain:       lightbox-jlg
+ * Domain Path:       /languages
  */
 
 // Sécurité
@@ -16,6 +18,15 @@ if ( ! defined( 'MGA_VERSION' ) ) {
 if ( ! defined( 'MGA_ADMIN_TEMPLATE_PATH' ) ) {
     define( 'MGA_ADMIN_TEMPLATE_PATH', plugin_dir_path( __FILE__ ) . 'includes/admin-page-template.php' );
 }
+
+/**
+ * Initialise la traduction du plugin.
+ */
+function mga_load_textdomain() {
+    load_plugin_textdomain( 'lightbox-jlg', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+}
+
+add_action( 'init', 'mga_load_textdomain' );
 
 /**
  * Supprime les données du plugin lors de la désinstallation.
@@ -52,13 +63,15 @@ function mga_enqueue_assets() {
 
     // Fichiers du plugin
     wp_enqueue_style('mga-gallery-style', plugin_dir_url( __FILE__ ) . 'assets/css/gallery-slideshow.css', [], MGA_VERSION);
-    $script_dependencies = ['swiper-js'];
+    $script_dependencies = [ 'swiper-js', 'wp-i18n' ];
     if ( ! empty( $settings['debug_mode'] ) ) {
-        wp_register_script('mga-debug-script', plugin_dir_url( __FILE__ ) . 'assets/js/debug.js', [], MGA_VERSION, true);
+        wp_register_script('mga-debug-script', plugin_dir_url( __FILE__ ) . 'assets/js/debug.js', [ 'wp-i18n' ], MGA_VERSION, true);
         wp_enqueue_script('mga-debug-script');
+        wp_set_script_translations( 'mga-debug-script', 'lightbox-jlg', plugin_dir_path( __FILE__ ) . 'languages' );
         $script_dependencies[] = 'mga-debug-script';
     }
     wp_enqueue_script('mga-gallery-script', plugin_dir_url( __FILE__ ) . 'assets/js/gallery-slideshow.js', $script_dependencies, MGA_VERSION, true);
+    wp_set_script_translations( 'mga-gallery-script', 'lightbox-jlg', plugin_dir_path( __FILE__ ) . 'languages' );
 
     // Passer les réglages au JavaScript
     wp_localize_script('mga-gallery-script', 'mga_settings', $settings);
@@ -204,8 +217,8 @@ function mga_post_has_eligible_images( $post = null ) {
  */
 function mga_add_admin_menu() {
     add_menu_page(
-        'Lightbox - JLG',
-        'Lightbox - JLG',
+        __( 'Lightbox - JLG', 'lightbox-jlg' ),
+        __( 'Lightbox - JLG', 'lightbox-jlg' ),
         'manage_options',
         'ma-galerie-automatique',
         'mga_options_page_html',
@@ -302,7 +315,8 @@ function mga_sanitize_settings( $input ) {
 function mga_admin_enqueue_assets($hook) {
     if ($hook != 'toplevel_page_ma-galerie-automatique') return;
     wp_enqueue_style('mga-admin-style', plugin_dir_url(__FILE__) . 'assets/css/admin-style.css', [], MGA_VERSION);
-    wp_enqueue_script('mga-admin-script', plugin_dir_url(__FILE__) . 'assets/js/admin-script.js', [], MGA_VERSION, true);
+    wp_enqueue_script('mga-admin-script', plugin_dir_url(__FILE__) . 'assets/js/admin-script.js', [ 'wp-i18n' ], MGA_VERSION, true);
+    wp_set_script_translations( 'mga-admin-script', 'lightbox-jlg', plugin_dir_path( __FILE__ ) . 'languages' );
 }
 add_action('admin_enqueue_scripts', 'mga_admin_enqueue_assets');
 


### PR DESCRIPTION
## Summary
- declare the plugin text domain and load translations during init
- internationalize admin UI strings and wrap interface text with the lightbox-jlg domain
- wire up script translation loading and replace JS labels with wp.i18n helpers

## Testing
- php -l ma-galerie-automatique/ma-galerie-automatique.php
- php -l ma-galerie-automatique/includes/admin-page-template.php

------
https://chatgpt.com/codex/tasks/task_e_68c91c846bd8832e8d6779f3381ebf95