### PR TITLE
Add activation hook to initialize default settings

### DIFF
--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -37,6 +37,29 @@ function mga_uninstall() {
 
 register_uninstall_hook( __FILE__, 'mga_uninstall' );
 
+/**
+ * Initialise les réglages lors de l'activation du plugin.
+ */
+function mga_activate() {
+    $defaults = mga_get_default_settings();
+    $existing_settings = get_option( 'mga_settings', false );
+
+    if ( false === $existing_settings ) {
+        add_option( 'mga_settings', $defaults );
+        return;
+    }
+
+    if ( is_array( $existing_settings ) ) {
+        $merged_settings = wp_parse_args( $existing_settings, $defaults );
+        update_option( 'mga_settings', mga_sanitize_settings( $merged_settings ) );
+        return;
+    }
+
+    update_option( 'mga_settings', $defaults );
+}
+
+register_activation_hook( __FILE__, 'mga_activate' );
+
 // ===== FRONT-END =====
 
 /**


### PR DESCRIPTION
## Summary
- add an activation handler that seeds the plugin settings with the defaults
- register the activation hook so the handler runs when the plugin is activated

## Testing
- php -l ma-galerie-automatique/ma-galerie-automatique.php

------
https://chatgpt.com/codex/tasks/task_e_68c9b2dfcf78832ebe15109cad3a8641