### PR TITLE
Réordonner le chargement des réglages

### DIFF
--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -51,12 +51,10 @@ function mga_enqueue_assets() {
 
     // Récupérer les réglages sauvegardés
     $defaults = mga_get_default_settings();
-    $saved_settings = get_option('mga_settings', $defaults);
-    $saved_settings = mga_sanitize_settings( $saved_settings );
+    $saved_settings = get_option( 'mga_settings', [] );
     // On s'assure que toutes les clés existent pour éviter les erreurs PHP
-    $settings = wp_parse_args($saved_settings, $defaults);
-    $resanitized_settings = mga_sanitize_settings( $settings );
-    $settings = $resanitized_settings;
+    $settings = wp_parse_args( (array) $saved_settings, $defaults );
+    $settings = mga_sanitize_settings( $settings );
 
     // Librairies (Mise à jour vers Swiper v11)
     $swiper_css = apply_filters( 'mga_swiper_css', plugin_dir_url( __FILE__ ) . 'assets/css/swiper-bundle.min.css' );
@@ -77,7 +75,7 @@ function mga_enqueue_assets() {
     wp_set_script_translations( 'mga-gallery-script', 'lightbox-jlg', plugin_dir_path( __FILE__ ) . 'languages' );
 
     // Passer les réglages au JavaScript
-    wp_localize_script('mga-gallery-script', 'mga_settings', $resanitized_settings);
+    wp_localize_script('mga-gallery-script', 'mga_settings', $settings);
 
     // Générer les styles dynamiques
     $accent_color = sanitize_hex_color($settings['accent_color']);


### PR DESCRIPTION
## Summary
- fusionner les réglages sauvegardés avec les valeurs par défaut avant de les assainir
- ne lancer qu’un seul passage par `mga_sanitize_settings()` et réutiliser le tableau assaini

## Testing
- php -l ma-galerie-automatique/ma-galerie-automatique.php

------
https://chatgpt.com/codex/tasks/task_e_68c9b2d5a028832eb61138fe4b4e3bda