### PR TITLE
Update slideshow regex to support additional image formats

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -64,7 +64,7 @@
         // --- FONCTIONS UTILITAIRES ---
         function getHighResUrl(linkElement) {
             if (!linkElement) return null;
-            if (/\.(jpe?g|png|gif|webp)$/i.test(linkElement.href)) return linkElement.href;
+            if (/\.(jpe?g|png|gif|bmp|webp|avif|svg)$/i.test(linkElement.href)) return linkElement.href;
             const innerImg = linkElement.querySelector('img');
             if (innerImg && innerImg.srcset) {
                 const sources = innerImg.srcset.split(',').map(s => {


### PR DESCRIPTION
## Summary
- include bmp, avif, and svg in the slideshow high-resolution URL regex
- confirm the PHP patterns already accept the same set of extensions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9b2d453b8832eb118623f33bb16e4