### PR TITLE
Ensure debug log escapes message content

### DIFF
--- a/ma-galerie-automatique/assets/js/debug.js
+++ b/ma-galerie-automatique/assets/js/debug.js
@@ -110,7 +110,15 @@
         }
         const entry = document.createElement('p');
         entry.style.cssText = `margin: 2px 5px; padding: 0; color: ${isError ? '#F44336' : '#4CAF50'}; font-size: 11px; word-break: break-all;`;
-        entry.innerHTML = `<span style="color:#888;">${mgaSprintf(mga__( '[%ss]', 'lightbox-jlg' ), time)}</span> > ${message}`;
+
+        const timestamp = document.createElement('span');
+        timestamp.style.color = '#888';
+        timestamp.textContent = mgaSprintf(mga__( '[%ss]', 'lightbox-jlg' ), time);
+
+        entry.appendChild(timestamp);
+        entry.appendChild(document.createTextNode(' > '));
+        entry.appendChild(document.createTextNode(String(message)));
+
         state.logContainer.appendChild(entry);
         state.logContainer.scrollTop = state.logContainer.scrollHeight;
     }


### PR DESCRIPTION
## Summary
- build debug panel log entries by appending DOM text nodes instead of concatenating HTML
- keep the timestamp styling while ensuring logged messages render as plain text

## Testing
- node <<'NODE' ... (manual DOM harness verifying `<` characters remain literal in the log output)


------
https://chatgpt.com/codex/tasks/task_e_68c9d6b036e0832e9f1d1fb74798e1f8