### PR TITLE
Documenter les fonctionnalités et le mode débogage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ Lightbox - JLG est un plugin WordPress qui transforme les galeries d'images en d
 - **Lecture en boucle** et **lancement automatique** du diaporama.
 - **Z‑index** de la galerie et **mode débogage**.
 
+## Fonctionnalités
+- **Compteur et légendes dynamiques** : chaque image affiche automatiquement sa légende ou, à défaut, son texte alternatif avec un compteur « image actuelle / total ».
+- **Lecture/Pause avec minuterie circulaire** : le bouton principal combine icônes lecture/pause et un timer SVG indiquant en temps réel le temps restant avant la prochaine diapositive (`assets/js/gallery-slideshow.js`, `assets/css/gallery-slideshow.css`).
+- **Zoom réactif** : le bouton loupe active le zoom Swiper pour inspecter les détails, avec prise en charge du glisser tactile pour se déplacer dans l’image.
+- **Affichage plein écran** : un bouton dédié bascule le navigateur en mode plein écran et l’icône « Fermer » ou la touche Échap permet de revenir à la page.
+- **Navigation clavier et commandes rapides** : les flèches du clavier, les boutons latéraux et les interactions tactiles permettent d’avancer ou de reculer, même en mode boucle.
+- **Miniatures synchronisées** : un carrousel de vignettes met en évidence la diapositive active et permet de changer d’image d’un clic ou d’un tap.
+
+### Mode débogage
+- **Activation** : cochez **Activer le mode débogage** dans les réglages du plugin (onglet **Réglages → Ma Galerie Automatique**, case issue de `includes/admin-page-template.php`).
+- **Panneau d’analyse** : `assets/js/debug.js` affiche un panneau flottant listant un chronomètre temps réel, le timer d’autoplay synchronisé au cercle de progression et un journal d’événements détaillé.
+- **Bouton de test** : le bouton **Forcer l’ouverture (Test)** insère instantanément une galerie de démonstration pour vérifier les comportements sans modifier vos contenus.
+
 ## Exemples d’utilisation
 Après l’activation :
 1. Éditez une page ou un article.


### PR DESCRIPTION
## Summary
- décrire dans le README les commandes interactives de la visionneuse (compteur, lecture/pause, zoom, plein écran, navigation, miniatures)
- ajouter un sous-chapitre sur l'activation et l'usage du panneau de débogage

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68c9dd70ab2c832e853b4cd0725b1589