### PR TITLE
Preserve body overflow when toggling viewer

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -32,6 +32,8 @@
         const preloadedUrls = new Set();
         let resizeTimeout;
         let isResizeListenerAttached = false;
+        let initialBodyOverflow = null;
+        let bodyOverflowWasModified = false;
 
         debug.init();
 
@@ -355,7 +357,14 @@
                 mainSwiper.slideToLoop(startIndex, 0);
                 updateInfo(viewer, images, startIndex);
                 viewer.style.display = 'flex';
-                document.body.style.overflow = 'hidden';
+                const previousOverflow = document.body.style.overflow;
+                initialBodyOverflow = previousOverflow;
+                if (previousOverflow !== 'hidden') {
+                    document.body.style.overflow = 'hidden';
+                    bodyOverflowWasModified = true;
+                } else {
+                    bodyOverflowWasModified = false;
+                }
                 debug.log(mga__( 'Galerie affichée avec succès.', 'lightbox-jlg' ));
                 if (!isResizeListenerAttached) {
                     window.addEventListener('resize', handleResize);
@@ -504,7 +513,11 @@
             window.removeEventListener('resize', handleResize);
             isResizeListenerAttached = false;
             viewer.style.display = 'none';
-            document.body.style.overflow = '';
+            if (bodyOverflowWasModified) {
+                document.body.style.overflow = initialBodyOverflow;
+            }
+            initialBodyOverflow = null;
+            bodyOverflowWasModified = false;
             debug.log(mga__( 'Galerie fermée.', 'lightbox-jlg' ));
             debug.stopTimer();
         }


### PR DESCRIPTION
## Summary
- track the initial body overflow at module scope when opening the viewer
- only override the overflow when necessary and restore it on close if it was changed

## Testing
- node - <<'NODE'
let initialBodyOverflow = null;
let bodyOverflowWasModified = false;

function openSimulation(currentOverflow) {
    const previousOverflow = currentOverflow;
    initialBodyOverflow = previousOverflow;
    if (previousOverflow !== 'hidden') {
        currentOverflow = 'hidden';
        bodyOverflowWasModified = true;
    } else {
        bodyOverflowWasModified = false;
    }
    return currentOverflow;
}

function closeSimulation(currentOverflow) {
    if (bodyOverflowWasModified) {
        currentOverflow = initialBodyOverflow;
    }
    initialBodyOverflow = null;
    bodyOverflowWasModified = false;
    return currentOverflow;
}

let bodyOverflow = 'scroll';
bodyOverflow = openSimulation(bodyOverflow);
console.log('After open (scroll -> hidden expected):', bodyOverflow);
bodyOverflow = closeSimulation(bodyOverflow);
console.log('After close (restored scroll expected):', bodyOverflow);

bodyOverflow = 'hidden';
bodyOverflow = openSimulation(bodyOverflow);
console.log('After open (hidden stays hidden):', bodyOverflow);
bodyOverflow = closeSimulation(bodyOverflow);
console.log('After close (still hidden expected):', bodyOverflow);
NODE

------
https://chatgpt.com/codex/tasks/task_e_68cb019211e0832eab3f27c9e978622b