### PR TITLE
Handle uninstall cleanup across multisite

### DIFF
--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -29,15 +29,6 @@ function mga_load_textdomain() {
 add_action( 'init', 'mga_load_textdomain' );
 
 /**
- * Supprime les données du plugin lors de la désinstallation.
- */
-function mga_uninstall() {
-    delete_option( 'mga_settings' );
-}
-
-register_uninstall_hook( __FILE__, 'mga_uninstall' );
-
-/**
  * Initialise les réglages lors de l'activation du plugin.
  */
 function mga_activate() {

--- a/ma-galerie-automatique/uninstall.php
+++ b/ma-galerie-automatique/uninstall.php
@@ -1,1 +1,18 @@
+<?php
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+    exit;
+}
 
+if ( is_multisite() ) {
+    $site_ids = get_sites( [ 'fields' => 'ids' ] );
+
+    foreach ( $site_ids as $site_id ) {
+        switch_to_blog( $site_id );
+        delete_option( 'mga_settings' );
+        restore_current_blog();
+    }
+
+    return;
+}
+
+delete_option( 'mga_settings' );


### PR DESCRIPTION
## Summary
- secure uninstall handler with guard and ensure mga_settings is deleted across all sites in multisite installs
- rely on uninstall.php for cleanup by removing redundant uninstall hook from the main plugin file

## Testing
- php -l ma-galerie-automatique/uninstall.php
- php -l ma-galerie-automatique/ma-galerie-automatique.php

------
https://chatgpt.com/codex/tasks/task_e_68cb1e6af74c832e9ad70426063408de