### PR TITLE
Load Swiper assets from CDN

### DIFF
--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -71,8 +71,19 @@ function mga_enqueue_assets() {
     $settings = mga_sanitize_settings( $settings );
 
     // Librairies (Mise à jour vers Swiper v11)
-    $swiper_css = apply_filters( 'mga_swiper_css', plugin_dir_url( __FILE__ ) . 'assets/css/swiper-bundle.min.css' );
-    $swiper_js  = apply_filters( 'mga_swiper_js', plugin_dir_url( __FILE__ ) . 'assets/js/swiper-bundle.min.js' );
+    $default_swiper_css = 'https://cdn.jsdelivr.net/npm/swiper@11.1.4/swiper-bundle.min.css';
+    $default_swiper_js  = 'https://cdn.jsdelivr.net/npm/swiper@11.1.4/swiper-bundle.min.js';
+
+    $swiper_css = apply_filters(
+        'mga_swiper_css',
+        $default_swiper_css
+    );
+
+    $swiper_js = apply_filters(
+        'mga_swiper_js',
+        $default_swiper_js
+    );
+
     wp_enqueue_style( 'swiper-css', $swiper_css, [], '11.1.4' );
     wp_enqueue_script( 'swiper-js', $swiper_js, [], '11.1.4', true );
 


### PR DESCRIPTION
## Summary
- load Swiper 11.1.4 scripts and styles from the official jsDelivr CDN by default
- retain filters allowing integrators to override Swiper asset URLs if needed

## Testing
- php -l ma-galerie-automatique/ma-galerie-automatique.php

------
https://chatgpt.com/codex/tasks/task_e_68cc4b197294832e87c1616355fb6735