### PR TITLE
Handle missing Swiper dependency gracefully

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -427,7 +427,12 @@
 
                 initSwiper(viewer, images);
                 if (!mainSwiper) {
-                    debug.log(mga__( 'Visionneuse annulée : Swiper n’a pas pu être initialisé.', 'lightbox-jlg' ), true);
+                    const cancelMessage = mga__( 'Visionneuse annulée : Swiper n’a pas pu être initialisé.', 'lightbox-jlg' );
+                    if (debug && typeof debug.log === 'function') {
+                        debug.log(cancelMessage, true);
+                    } else if (typeof console !== 'undefined' && typeof console.error === 'function') {
+                        console.error(cancelMessage);
+                    }
                     viewer.style.display = 'none';
                     return;
                 }
@@ -538,7 +543,12 @@
             });
 
             if (!thumbsSwiper) {
-                debug.log(mga__( 'Initialisation des miniatures Swiper impossible. La visionneuse fonctionnera sans elles.', 'lightbox-jlg' ), true);
+                const thumbsMessage = mga__( 'Initialisation des miniatures Swiper impossible. La visionneuse fonctionnera sans elles.', 'lightbox-jlg' );
+                if (debug && typeof debug.log === 'function') {
+                    debug.log(thumbsMessage, true);
+                } else if (typeof console !== 'undefined' && typeof console.error === 'function') {
+                    console.error(thumbsMessage);
+                }
             }
 
             // L'instance principale peut activer `loop` en fonction des réglages.
@@ -598,7 +608,12 @@
             mainSwiper = createSwiperInstance(mainSwiperContainer, mainSwiperConfig);
 
             if (!mainSwiper) {
-                debug.log(mga__( 'Initialisation du Swiper principal impossible. Visionneuse indisponible.', 'lightbox-jlg' ), true);
+                const mainMessage = mga__( 'Initialisation du Swiper principal impossible. Visionneuse indisponible.', 'lightbox-jlg' );
+                if (debug && typeof debug.log === 'function') {
+                    debug.log(mainMessage, true);
+                } else if (typeof console !== 'undefined' && typeof console.error === 'function') {
+                    console.error(mainMessage);
+                }
                 return;
             }
 


### PR DESCRIPTION
## Summary
- add fallback logging when Swiper cannot be initialised so debug mode and the console report the issue
- guard the viewer bootstrap so missing Swiper instances halt cleanly without triggering runtime errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc50b52f48832ebb4f37fb89878829