### PR TITLE
Handle missing autoplay in resize handler

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -802,11 +802,12 @@
             clearTimeout(resizeTimeout);
             resizeTimeout = setTimeout(() => {
                 if (mainSwiper && mainSwiper.el && !mainSwiper.destroyed) {
-                    const wasRunning = mainSwiper.autoplay.running;
+                    const autoplayInstance = mainSwiper.autoplay;
+                    const wasRunning = Boolean(autoplayInstance && autoplayInstance.running);
                     debug.log(mga__( 'Redimensionnement détecté. Mise à jour de Swiper.', 'lightbox-jlg' ));
                     mainSwiper.update();
                     if(thumbsSwiper && !thumbsSwiper.destroyed) thumbsSwiper.update();
-                    if (wasRunning) {
+                    if (wasRunning && mainSwiper.autoplay && typeof mainSwiper.autoplay.start === 'function') {
                         mainSwiper.autoplay.start();
                         debug.log(mga__( 'Autoplay relancé après redimensionnement.', 'lightbox-jlg' ));
                     }


### PR DESCRIPTION
## Summary
- add guards in the resize handler to avoid touching autoplay when the module is unavailable
- ensure autoplay is only restarted when it previously existed and was running

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc633f6014832eb94ee5bccaf68b91