### PR TITLE
Add guard when sanitizing settings

### DIFF
--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -430,6 +430,10 @@ function mga_get_default_settings() {
  * Nettoie les données envoyées.
  */
 function mga_sanitize_settings( $input ) {
+    if ( ! is_array( $input ) ) {
+        $input = [];
+    }
+
     $defaults = mga_get_default_settings();
     $output = [];
 


### PR DESCRIPTION
## Summary
- avoid PHP warnings by coercing unexpected sanitize input to an empty array before processing

## Testing
- php -l ma-galerie-automatique/ma-galerie-automatique.php

------
https://chatgpt.com/codex/tasks/task_e_68cd75cf8b80832eb846929593c38190