### PR TITLE
Adjust click handler propagation for gallery viewer

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -426,7 +426,6 @@
 
                 if (startIndex !== -1) {
                     e.preventDefault();
-                    e.stopPropagation();
                     lastFocusedElementBeforeViewer = document.activeElement;
                     openViewer(galleryData, startIndex);
                 } else {
@@ -434,7 +433,7 @@
                     debug.log(mgaSprintf(mga__( 'URL cliquée recherchée : %s', 'lightbox-jlg' ), clickedHighResUrl), true);
                 }
             }
-        }, true);
+        });
 
         function openViewer(images, startIndex) {
             debug.log(mgaSprintf(mga__( 'openViewer appelé avec %1$d images, index %2$d.', 'lightbox-jlg' ), images.length, startIndex));


### PR DESCRIPTION
## Summary
- remove click listener capture option so events bubble to external handlers
- stop using stopPropagation when opening the viewer to allow analytics listeners to run

## Testing
- not run (browser-based behaviour requires manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68cdc80e889c832e8b20d1058b53a409