### PR TITLE
Respect user-intended navigation for gallery links

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -394,8 +394,29 @@
         });
 
         contentArea.addEventListener('click', function (e) {
+            if (e.defaultPrevented) {
+                return;
+            }
+
+            if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+                return;
+            }
+
             const targetLink = e.target.closest('a');
-            if (targetLink && targetLink.querySelector('img')) {
+            if (!targetLink) {
+                return;
+            }
+
+            const linkTarget = targetLink.getAttribute('target');
+            if (typeof linkTarget === 'string' && linkTarget.toLowerCase() === '_blank') {
+                return;
+            }
+
+            if (targetLink.hasAttribute('download')) {
+                return;
+            }
+
+            if (targetLink.querySelector('img')) {
                 debug.log(mga__( 'Clic sur un lien contenant une image.', 'lightbox-jlg' ));
 
                 const clickedHighResUrl = getHighResUrl(targetLink);


### PR DESCRIPTION
## Summary
- add early exit guards in the gallery click handler to honour default-prevented events, modifier keys, and download/new-tab links
- keep lightbox activation for simple clicks while letting the browser handle new tabs or downloads

## Testing
- not run (requires manual front-end verification)

------
https://chatgpt.com/codex/tasks/task_e_68ce8a199318832e9793d9c2022d3a32