### PR TITLE
Handle lazy-loaded thumbnails in slideshow

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -434,7 +434,13 @@
                     const highResUrl = getHighResUrl(link);
                     if (!highResUrl) return null;
 
-                    const thumbUrl = innerImg.src;
+                    const dataAttributeUrl = getImageDataAttributes(innerImg);
+                    const thumbUrlCandidate = dataAttributeUrl || innerImg.currentSrc || innerImg.src || '';
+                    const thumbUrl = thumbUrlCandidate ? thumbUrlCandidate.trim() : '';
+
+                    if (!thumbUrl) {
+                        return null;
+                    }
 
                     let caption = '';
                     const figure = link.closest('figure');


### PR DESCRIPTION
## Summary
- build thumbnail URLs by reusing getImageDataAttributes before falling back to currentSrc and src
- skip gallery items when no thumbnail URL can be resolved to avoid broken thumbs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce8f3db274832eacaae34cee4af198