### PR TITLE
Add accessible label to slideshow viewer dialog

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -299,7 +299,7 @@
             if (!viewer) {
                 debug.log(mga__( 'Viewer non trouvé. Création à la volée...', 'lightbox-jlg' ));
                 const viewerHTML = `
-                    <div id="mga-viewer" class="mga-viewer" style="display: none;" role="dialog" aria-modal="true">
+                    <div id="mga-viewer" class="mga-viewer" style="display: none;" role="dialog" aria-modal="true" aria-label="${mga__( 'Visionneuse d’images', 'lightbox-jlg' )}">
                         <div class="mga-echo-bg"></div>
                         
                         <div class="mga-header">


### PR DESCRIPTION
## Summary
- add an accessible, localized label to the lightbox dialog so screen readers announce it correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce8f3eb2e4832eba1acd0a8cf67a2d