### PR TITLE
Fix thumbnail resolution for slideshow data

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -434,7 +434,14 @@
                     const highResUrl = getHighResUrl(link);
                     if (!highResUrl) return null;
 
-                    const thumbUrl = innerImg.src;
+                    let thumbUrl = getImageDataAttributes(innerImg);
+                    if (!thumbUrl && innerImg.currentSrc) {
+                        thumbUrl = innerImg.currentSrc;
+                    }
+                    if (!thumbUrl && innerImg.src) {
+                        thumbUrl = innerImg.src;
+                    }
+                    if (!thumbUrl) return null;
 
                     let caption = '';
                     const figure = link.closest('figure');


### PR DESCRIPTION
## Summary
- reuse `getImageDataAttributes` when resolving slideshow thumbnails and fallback to `currentSrc`/`src`
- skip gallery entries lacking a usable thumbnail URL to avoid broken previews

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce8eedc648832e89ff56db82ac80f0