### PR TITLE
Handle lazy-loaded thumbnails in gallery slideshow

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -434,7 +434,16 @@
                     const highResUrl = getHighResUrl(link);
                     if (!highResUrl) return null;
 
-                    const thumbUrl = innerImg.src;
+                    let thumbUrl = getImageDataAttributes(innerImg);
+                    if (typeof thumbUrl === 'string') {
+                        thumbUrl = thumbUrl.trim();
+                    }
+                    if (!thumbUrl) {
+                        thumbUrl = innerImg.currentSrc || innerImg.src || '';
+                    }
+                    if (!thumbUrl) {
+                        return null;
+                    }
 
                     let caption = '';
                     const figure = link.closest('figure');


### PR DESCRIPTION
## Summary
- reuse existing data-attribute resolution when building gallery thumbnails
- fall back to currentSrc/src and skip entries without a usable thumbnail

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce90482f84832ebeb193e77a3e1fcd