### PR TITLE
Relance automatique du chronomètre debug

### DIFF
--- a/ma-galerie-automatique/assets/js/debug.js
+++ b/ma-galerie-automatique/assets/js/debug.js
@@ -100,6 +100,10 @@
         }, 100);
     }
 
+    function restartTimer() {
+        startTimer();
+    }
+
     function stopTimer() {
         if (state.timerInterval) {
             clearInterval(state.timerInterval);
@@ -195,6 +199,7 @@
         updateInfo,
         onForceOpen,
         stopTimer,
+        restartTimer,
         table,
     };
 })(window);

--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -25,6 +25,7 @@
             updateInfo: noop,
             onForceOpen: noop,
             stopTimer: noop,
+            restartTimer: noop,
             table: noop,
         };
         let mainSwiper = null;
@@ -474,6 +475,9 @@
 
         function openViewer(images, startIndex) {
             debug.log(mgaSprintf(mga__( 'openViewer appelé avec %1$d images, index %2$d.', 'lightbox-jlg' ), images.length, startIndex));
+            if (debug && typeof debug.restartTimer === 'function') {
+                debug.restartTimer();
+            }
             const viewer = getViewer();
             if (!viewer) return;
 


### PR DESCRIPTION
## Summary
- expose a new `restartTimer` helper in the debug panel API so the real-time counter can be restarted externally
- invoke the restart helper when opening the gallery viewer to relaunch the debug timer after a stop

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ceaaf8dae0832e9fdca4e9385b31ab