### PR TITLE
Restart debug timer when reopening viewer

### DIFF
--- a/ma-galerie-automatique/assets/js/debug.js
+++ b/ma-galerie-automatique/assets/js/debug.js
@@ -195,6 +195,7 @@
         updateInfo,
         onForceOpen,
         stopTimer,
+        restartTimer: startTimer,
         table,
     };
 })(window);

--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -25,6 +25,7 @@
             updateInfo: noop,
             onForceOpen: noop,
             stopTimer: noop,
+            restartTimer: noop,
             table: noop,
         };
         let mainSwiper = null;
@@ -523,6 +524,9 @@
 
         function openViewer(images, startIndex) {
             debug.log(mgaSprintf(mga__( 'openViewer appelé avec %1$d images, index %2$d.', 'lightbox-jlg' ), images.length, startIndex));
+            if (typeof debug.restartTimer === 'function') {
+                debug.restartTimer();
+            }
             const viewer = getViewer();
             if (!viewer) return;
 


### PR DESCRIPTION
## Summary
- expose the internal timer restart helper through the debug panel API
- restart the debug timer automatically when the gallery viewer is opened

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cee38364b8832ebbb433bd774a8c47