### PR TITLE
Refactor gallery init to support deferred scripts

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -14,7 +14,7 @@
             });
         };
 
-    document.addEventListener('DOMContentLoaded', function() {
+    function initGalleryViewer() {
         const settings = window.mga_settings || {};
         const IMAGE_FILE_PATTERN = /\.(jpe?g|png|gif|bmp|webp|avif|svg)(?:\?.*)?(?:#.*)?$/i;
         const noop = () => {};
@@ -992,5 +992,11 @@
                 }
             }, 250);
         }
-    });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initGalleryViewer);
+    } else {
+        initGalleryViewer();
+    }
 })();


### PR DESCRIPTION
## Summary
- extract the gallery initialisation routine into an `initGalleryViewer` helper
- guard DOMContentLoaded registration so deferred scripts initialise immediately

## Testing
- node - <<'NODE' ... (custom harness to simulate `document.readyState === "interactive"`)


------
https://chatgpt.com/codex/tasks/task_e_68cf38d84be4832eba0e701e8a0c38c1