### PR TITLE
Ensure multisite uninstall removes all mga_settings options

### DIFF
--- a/ma-galerie-automatique/uninstall.php
+++ b/ma-galerie-automatique/uninstall.php
@@ -4,7 +4,12 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 }
 
 if ( is_multisite() ) {
-    $site_ids = get_sites( [ 'fields' => 'ids' ] );
+    $site_ids = get_sites(
+        [
+            'fields' => 'ids',
+            'number' => 0,
+        ]
+    );
 
     foreach ( $site_ids as $site_id ) {
         switch_to_blog( $site_id );


### PR DESCRIPTION
## Summary
- include the `number => 0` argument when retrieving site IDs during uninstall to iterate every site in a network

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cf411b1724832e9d9b078afc714d36