### PR TITLE
Restreindre l'utilisation des URL data pour la lightbox

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -368,7 +368,11 @@
         function getHighResUrl(linkElement) {
             if (!linkElement) return null;
 
-            if (linkElement.dataset && linkElement.dataset.mgaHighres) {
+            const href = linkElement.getAttribute('href') || '';
+            const isMediaHref = IMAGE_FILE_PATTERN.test(href);
+            const fallbackAllowed = isMediaHref || isExplicitFallbackAllowed(linkElement);
+
+            if (fallbackAllowed && linkElement.dataset && linkElement.dataset.mgaHighres) {
                 const sanitizedDatasetUrl = sanitizeHighResUrl(linkElement.dataset.mgaHighres);
                 if (sanitizedDatasetUrl) {
                     return sanitizedDatasetUrl;
@@ -378,15 +382,13 @@
             const innerImg = linkElement.querySelector('img');
             if (!innerImg) return null;
 
-            const dataAttrUrl = getImageDataAttributes(innerImg);
-            const sanitizedDataAttrUrl = sanitizeHighResUrl(dataAttrUrl);
-            if (sanitizedDataAttrUrl) {
-                return sanitizedDataAttrUrl;
+            if (fallbackAllowed) {
+                const dataAttrUrl = getImageDataAttributes(innerImg);
+                const sanitizedDataAttrUrl = sanitizeHighResUrl(dataAttrUrl);
+                if (sanitizedDataAttrUrl) {
+                    return sanitizedDataAttrUrl;
+                }
             }
-
-            const href = linkElement.getAttribute('href') || '';
-            const isMediaHref = IMAGE_FILE_PATTERN.test(href);
-            const fallbackAllowed = isMediaHref || isExplicitFallbackAllowed(linkElement);
 
             if (!fallbackAllowed) {
                 return null;


### PR DESCRIPTION
## Summary
- limite l'utilisation des URL data-* aux liens autorisés ou pointant déjà vers un média
- évite de récupérer les attributs data-* lorsqu'ils ne sont pas éligibles comme source haute résolution

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cff9aa5a8c832eb783fd63419a8f8f