### PR TITLE
Ensure lightbox opens correct slide when duplicates exist

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -553,17 +553,24 @@
 
                 const triggerLinks = getTriggerLinks();
 
-                const galleryData = triggerLinks.map(link => {
+                const clickedTriggerIndex = triggerLinks.indexOf(targetLink);
+                if (clickedTriggerIndex === -1) {
+                    debug.log(mga__( "ERREUR : Lien déclencheur introuvable dans la collection actuelle.", 'lightbox-jlg' ), true);
+                    return;
+                }
+
+                const galleryData = [];
+                triggerLinks.forEach((link, index) => {
                     const innerImg = link.querySelector('img');
-                    if (!innerImg) return null;
+                    if (!innerImg) return;
 
                     const highResUrl = getHighResUrl(link);
-                    if (!highResUrl) return null;
+                    if (!highResUrl) return;
 
                     const thumbUrl = resolveThumbnailUrl(innerImg);
 
                     if (!thumbUrl) {
-                        return null;
+                        return;
                     }
 
                     let caption = '';
@@ -576,13 +583,13 @@
                         caption = innerImg.alt || '';
                     }
 
-                    return { highResUrl, thumbUrl, caption };
-                }).filter(Boolean);
+                    galleryData.push({ highResUrl, thumbUrl, caption, triggerIndex: index });
+                });
 
                 debug.log(mgaSprintf(mga__( '%d images valides préparées pour la galerie.', 'lightbox-jlg' ), galleryData.length));
                 debug.table(galleryData);
 
-                const startIndex = galleryData.findIndex(img => img.highResUrl === clickedHighResUrl);
+                const startIndex = galleryData.findIndex(img => img.triggerIndex === clickedTriggerIndex);
 
                 if (startIndex !== -1) {
                     e.preventDefault();


### PR DESCRIPTION
## Summary
- track the index of each trigger link when building the gallery data
- use the stored trigger index to open the correct slide even if URLs repeat
- guard against cases where the clicked link is no longer part of the trigger list

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d045d5692c832e840430fb2dc3aecd