### PR TITLE
Respect user loop setting for two-image galleries

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -808,7 +808,7 @@
             const mainSwiperConfig = {
                 zoom: true,
                 spaceBetween: 10,
-                loop: !!settings.loop && images.length > 2,
+                loop: !!settings.loop,
                 navigation: { nextEl: '.swiper-button-next', prevEl: '.swiper-button-prev' },
                 autoplay: {
                     delay: parseInt(settings.delay, 10) * 1000 || 4000,


### PR DESCRIPTION
## Summary
- ensure the main Swiper loop option mirrors the user setting regardless of gallery size

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d07e0f6754832ebacb5786bb68e059