### PR TITLE
Rename Swiper asset handles

### DIFF
--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -92,12 +92,12 @@ function mga_enqueue_assets() {
     }
     $swiper_js = apply_filters( 'mga_swiper_js', $swiper_js, $swiper_version );
 
-    wp_enqueue_style( 'swiper-css', $swiper_css, [], $swiper_version );
-    wp_enqueue_script( 'swiper-js', $swiper_js, [], $swiper_version, true );
+    wp_enqueue_style( 'mga-swiper-css', $swiper_css, [], $swiper_version );
+    wp_enqueue_script( 'mga-swiper-js', $swiper_js, [], $swiper_version, true );
 
     // Fichiers du plugin
     wp_enqueue_style('mga-gallery-style', plugin_dir_url( __FILE__ ) . 'assets/css/gallery-slideshow.css', [], MGA_VERSION);
-    $script_dependencies = [ 'swiper-js', 'wp-i18n' ];
+    $script_dependencies = [ 'mga-swiper-js', 'wp-i18n' ];
     if ( ! empty( $settings['debug_mode'] ) ) {
         $can_view_debug = apply_filters(
             'mga_user_can_view_debug',


### PR DESCRIPTION
## Summary
- rename Swiper style and script handles to mga-prefixed versions
- update plugin dependencies to use the new Swiper script handle

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d181269380832e9d99faaa362ff2a0