### PR TITLE
Prioritize media href before img fallbacks

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -371,6 +371,7 @@
             const href = linkElement.getAttribute('href') || '';
             const isMediaHref = IMAGE_FILE_PATTERN.test(href);
             const fallbackAllowed = isMediaHref || isExplicitFallbackAllowed(linkElement);
+            const sanitizedHref = isMediaHref ? sanitizeHighResUrl(href) : null;
 
             if (fallbackAllowed && linkElement.dataset && linkElement.dataset.mgaHighres) {
                 const sanitizedDatasetUrl = sanitizeHighResUrl(linkElement.dataset.mgaHighres);
@@ -399,6 +400,10 @@
                 return srcsetUrl;
             }
 
+            if (sanitizedHref) {
+                return sanitizedHref;
+            }
+
             const currentSrc = sanitizeHighResUrl(innerImg.currentSrc);
             if (currentSrc) {
                 return currentSrc;
@@ -407,13 +412,6 @@
             const fallbackSrc = sanitizeHighResUrl(innerImg.src);
             if (fallbackSrc) {
                 return fallbackSrc;
-            }
-
-            if (isMediaHref) {
-                const sanitizedHref = sanitizeHighResUrl(href);
-                if (sanitizedHref) {
-                    return sanitizedHref;
-                }
             }
 
             return null;


### PR DESCRIPTION
## Summary
- sanitize the gallery link href up front when it targets an image file
- return the sanitized href before falling back to currentSrc/src while keeping data attribute and srcset priority

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1c97e6e14832ea985756aa621f2a8