### PR TITLE
Add defaults and sanitization for content selector settings

### DIFF
--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -452,6 +452,8 @@ function mga_get_default_settings() {
         'background_style' => 'echo',
         'z_index' => 99999,
         'debug_mode' => false,
+        'contentSelectors' => [],
+        'allowBodyFallback' => true,
     ];
 }
 
@@ -510,6 +512,21 @@ function mga_sanitize_settings( $input ) {
         $output['z_index'] = $defaults['z_index'];
     }
     $output['debug_mode'] = ! empty( $input['debug_mode'] );
+
+    $content_selectors = is_array( $defaults['contentSelectors'] ) ? $defaults['contentSelectors'] : [];
+    if ( isset( $input['contentSelectors'] ) && is_array( $input['contentSelectors'] ) ) {
+        foreach ( $input['contentSelectors'] as $selector ) {
+            $sanitized_selector = trim( sanitize_text_field( (string) $selector ) );
+
+            if ( '' !== $sanitized_selector ) {
+                $content_selectors[] = $sanitized_selector;
+            }
+        }
+    }
+    $output['contentSelectors'] = $content_selectors;
+    $output['allowBodyFallback'] = isset( $input['allowBodyFallback'] )
+        ? (bool) $input['allowBodyFallback']
+        : (bool) $defaults['allowBodyFallback'];
 
     return $output;
 }


### PR DESCRIPTION
## Summary
- add default values for gallery content selectors and fallback flag
- sanitize these options when saving settings to keep valid strings and boolean

## Testing
- php -l ma-galerie-automatique/ma-galerie-automatique.php

------
https://chatgpt.com/codex/tasks/task_e_68d2834b176c832e857ebde9aa5f73f7