### PR TITLE
Disable body fallback by default

### DIFF
--- a/ma-galerie-automatique/includes/admin-page-template.php
+++ b/ma-galerie-automatique/includes/admin-page-template.php
@@ -91,6 +91,12 @@ $settings = wp_parse_args( $settings, $defaults );
                                 <span><?php echo esc_html__( 'Lancement auto. du diaporama', 'lightbox-jlg' ); ?></span>
                             </label>
                             <p class="description"><?php echo esc_html__( "Si coché, le diaporama démarre automatiquement à l'ouverture de la galerie.", 'lightbox-jlg' ); ?></p>
+                            <br>
+                            <label for="mga_allow_body_fallback">
+                                <input name="mga_settings[allowBodyFallback]" type="checkbox" id="mga_allow_body_fallback" value="1" <?php checked( ! empty( $settings['allowBodyFallback'] ), 1 ); ?> />
+                                <span><?php echo esc_html__( 'Autoriser le repli sur &lt;body&gt;', 'lightbox-jlg' ); ?></span>
+                            </label>
+                            <p class="description"><?php echo esc_html__( "Active un repli sur l'élément &lt;body&gt; si le thème ne propose pas de zone de contenu compatible.", 'lightbox-jlg' ); ?></p>
                         </fieldset>
                     </td>
                 </tr>

--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -453,7 +453,7 @@ function mga_get_default_settings() {
         'z_index' => 99999,
         'debug_mode' => false,
         'contentSelectors' => [],
-        'allowBodyFallback' => true,
+        'allowBodyFallback' => false,
     ];
 }
 


### PR DESCRIPTION
## Summary
- default the allowBodyFallback option to false so the plugin no longer falls back implicitly
- add an admin checkbox to let site owners opt back into the body fallback when required

## Testing
- php -l ma-galerie-automatique/ma-galerie-automatique.php
- php -l ma-galerie-automatique/includes/admin-page-template.php

------
https://chatgpt.com/codex/tasks/task_e_68d2d4d1d3ac832e8f57462264d7dfd7