### PR TITLE
Make body fallback opt-in

### DIFF
--- a/ma-galerie-automatique/includes/admin-page-template.php
+++ b/ma-galerie-automatique/includes/admin-page-template.php
@@ -91,6 +91,12 @@ $settings = wp_parse_args( $settings, $defaults );
                                 <span><?php echo esc_html__( 'Lancement auto. du diaporama', 'lightbox-jlg' ); ?></span>
                             </label>
                             <p class="description"><?php echo esc_html__( "Si coché, le diaporama démarre automatiquement à l'ouverture de la galerie.", 'lightbox-jlg' ); ?></p>
+                            <br>
+                            <label for="mga_allow_body_fallback">
+                                <input name="mga_settings[allowBodyFallback]" type="checkbox" id="mga_allow_body_fallback" value="1" <?php checked( ! empty( $settings['allowBodyFallback'] ), 1 ); ?> />
+                                <span><?php echo esc_html__( 'Activer le repli sur le corps de page', 'lightbox-jlg' ); ?></span>
+                            </label>
+                            <p class="description"><?php echo esc_html__( 'Utilisez ce repli si votre thème ne fournit aucun conteneur compatible pour la galerie.', 'lightbox-jlg' ); ?></p>
                         </fieldset>
                     </td>
                 </tr>

--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -453,7 +453,7 @@ function mga_get_default_settings() {
         'z_index' => 99999,
         'debug_mode' => false,
         'contentSelectors' => [],
-        'allowBodyFallback' => true,
+        'allowBodyFallback' => false,
     ];
 }
 


### PR DESCRIPTION
## Summary
- disable the automatic body fallback in the default settings to avoid implicit opt-in
- add an admin checkbox allowing site owners to explicitly enable the body fallback when needed

## Testing
- php -l ma-galerie-automatique/ma-galerie-automatique.php
- php -l ma-galerie-automatique/includes/admin-page-template.php

------
https://chatgpt.com/codex/tasks/task_e_68d2e025588c832e9e497905a6a0cb33