### PR TITLE
Check opacity slider elements before binding

### DIFF
--- a/ma-galerie-automatique/assets/js/admin-script.js
+++ b/ma-galerie-automatique/assets/js/admin-script.js
@@ -43,5 +43,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const opacitySlider = document.getElementById('mga_bg_opacity');
     const opacityValue = document.getElementById('mga_bg_opacity_value');
-    if(opacitySlider) opacitySlider.addEventListener('input', () => opacityValue.textContent = opacitySlider.value);
+    if (opacitySlider && opacityValue) {
+        opacitySlider.addEventListener('input', () => {
+            opacityValue.textContent = opacitySlider.value;
+        });
+    }
 });


### PR DESCRIPTION
## Summary
- guard the opacity slider event binding so it only runs when both slider and display element exist

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d31e9affbc832e9a0606377facece4