### PR TITLE
Load translations earlier in WordPress lifecycle

### DIFF
--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -26,7 +26,7 @@ function mga_load_textdomain() {
     load_plugin_textdomain( 'lightbox-jlg', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
 }
 
-add_action( 'init', 'mga_load_textdomain' );
+add_action( 'plugins_loaded', 'mga_load_textdomain' );
 
 /**
  * Initialise les réglages lors de l'activation du plugin.


### PR DESCRIPTION
## Summary
- hook the textdomain loader on `plugins_loaded` instead of `init` to ensure translations are ready for early hooks

## Testing
- php -l ma-galerie-automatique/ma-galerie-automatique.php

------
https://chatgpt.com/codex/tasks/task_e_68d3a5fbe064832e9b6c73a55a48aa80