### PR TITLE
Ensure Swiper assets fallback and harden event handling

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -40,6 +40,30 @@
 
         debug.init();
 
+        function resolveEventTarget(event) {
+            if (!event || !event.target) {
+                return null;
+            }
+
+            const target = event.target;
+
+            if (target instanceof Element) {
+                return target;
+            }
+
+            if (target && typeof target === 'object') {
+                if (target.parentElement instanceof Element) {
+                    return target.parentElement;
+                }
+
+                if (target.parentNode instanceof Element) {
+                    return target.parentNode;
+                }
+            }
+
+            return null;
+        }
+
         /**
          * Swiper peut afficher des avertissements « Swiper Loop Warning » lorsque
          * l'option `loop` est active mais que la configuration n'offre pas assez
@@ -780,7 +804,12 @@
                 return;
             }
 
-            const targetLink = e.target.closest('a');
+            const eventTarget = resolveEventTarget(e);
+            if (!eventTarget) {
+                return;
+            }
+
+            const targetLink = eventTarget.closest('a');
             if (!targetLink) {
                 return;
             }
@@ -1169,10 +1198,14 @@
         document.body.addEventListener('click', function(e) {
             const viewer = document.getElementById('mga-viewer');
             if (!viewer || viewer.style.display === 'none') return;
-            if (e.target.closest('#mga-close')) closeViewer(viewer);
-            if (e.target.closest('#mga-play-pause')) { if (mainSwiper && mainSwiper.autoplay && mainSwiper.autoplay.running) mainSwiper.autoplay.stop(); else if (mainSwiper && mainSwiper.autoplay) mainSwiper.autoplay.start(); }
-            if (e.target.closest('#mga-zoom')) { if (mainSwiper && mainSwiper.zoom) mainSwiper.zoom.toggle(); }
-            if (e.target.closest('#mga-fullscreen')) {
+            const eventTarget = resolveEventTarget(e);
+            if (!eventTarget) {
+                return;
+            }
+            if (eventTarget.closest('#mga-close')) closeViewer(viewer);
+            if (eventTarget.closest('#mga-play-pause')) { if (mainSwiper && mainSwiper.autoplay && mainSwiper.autoplay.running) mainSwiper.autoplay.stop(); else if (mainSwiper && mainSwiper.autoplay) mainSwiper.autoplay.start(); }
+            if (eventTarget.closest('#mga-zoom')) { if (mainSwiper && mainSwiper.zoom) mainSwiper.zoom.toggle(); }
+            if (eventTarget.closest('#mga-fullscreen')) {
                 const { request: requestFullscreen, exit: exitFullscreen, element: fullscreenElement } = resolveFullscreenApi(viewer);
 
                 if (!fullscreenElement) {

--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -139,6 +139,13 @@ function mga_enqueue_assets() {
 
     $asset_sources = mga_get_swiper_asset_sources();
 
+    if (
+        ( 'local' === $asset_sources['css'] && ! file_exists( $local_swiper_css_path ) ) ||
+        ( 'local' === $asset_sources['js'] && ! file_exists( $local_swiper_js_path ) )
+    ) {
+        $asset_sources = mga_refresh_swiper_asset_sources();
+    }
+
     $swiper_css = 'local' === $asset_sources['css'] ? $local_swiper_css_url : $cdn_swiper_css;
     $swiper_css = apply_filters( 'mga_swiper_css', $swiper_css, $swiper_version );
 

--- a/ma-galerie-automatique/uninstall.php
+++ b/ma-galerie-automatique/uninstall.php
@@ -14,6 +14,7 @@ if ( is_multisite() ) {
     foreach ( $site_ids as $site_id ) {
         switch_to_blog( $site_id );
         delete_option( 'mga_settings' );
+        delete_option( 'mga_swiper_asset_sources' );
         restore_current_blog();
     }
 
@@ -21,3 +22,4 @@ if ( is_multisite() ) {
 }
 
 delete_option( 'mga_settings' );
+delete_option( 'mga_swiper_asset_sources' );


### PR DESCRIPTION
## Summary
- refresh the cached Swiper asset sources during enqueue when the local files are missing so the CDN fallback works automatically
- remove the cached Swiper asset option during uninstall for all sites
- normalize click event targets before querying with closest to avoid exceptions from Text nodes

## Testing
- php -l ma-galerie-automatique/ma-galerie-automatique.php
- php -l ma-galerie-automatique/uninstall.php

------
https://chatgpt.com/codex/tasks/task_e_68d3c50b9c18832ebc11137ebc6d7ea1