### PR TITLE
Improve asset detection and translation loading

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -699,9 +699,21 @@
         debug.log(mga__( 'Script initialisé et prêt.', 'lightbox-jlg' ));
         debug.updateInfo('mga-debug-status', mga__( 'Prêt', 'lightbox-jlg' ), '#4CAF50');
 
-        const defaultContentSelectors = ['.wp-block-post-content', '.entry-content', '.post-content'];
+        const defaultContentSelectors = [
+            '.wp-block-post-content',
+            '.entry-content',
+            '.post-content',
+            '.site-main',
+            '.content-area',
+            'main',
+            '.hentry',
+            '#primary',
+            '#main'
+        ];
         const configuredSelectors = Array.isArray(settings.contentSelectors) ? settings.contentSelectors : [];
-        const contentSelectors = configuredSelectors.concat(defaultContentSelectors).filter(Boolean);
+        const contentSelectors = Array.from(
+            new Set(configuredSelectors.concat(defaultContentSelectors).filter(Boolean))
+        );
         let contentArea = null;
         let foundSelector = mga__( 'Aucune zone détectée', 'lightbox-jlg' );
         for (const selector of contentSelectors) {

--- a/ma-galerie-automatique/languages/README.md
+++ b/ma-galerie-automatique/languages/README.md
@@ -1,0 +1,3 @@
+# Traductions du plugin
+
+Déposez ici les fichiers de traduction (`.po`, `.mo`, `.json`) générés pour le domaine `lightbox-jlg`.


### PR DESCRIPTION
## Summary
- guard translation loading and script localization behind a reusable languages directory helper and expose frontend selector filters
- streamline asset detection by short-cutting empty content, reusing has_block when available and skipping heavy regex when anchors are absent
- broaden default frontend selectors and document the expected translation folder structure

## Testing
- php -l ma-galerie-automatique.php

------
https://chatgpt.com/codex/tasks/task_e_68d3dab1a07c832e8e15b12574bbf666