### PR TITLE
Fix settings exposure and clean cached meta on uninstall

### DIFF
--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -238,7 +238,7 @@ function mga_enqueue_assets() {
     if ( false !== $settings_json ) {
         wp_add_inline_script(
             'mga-gallery-script',
-            'const mgaSettings = ' . $settings_json . ';',
+            'window.mga_settings = ' . $settings_json . ";\nwindow.mgaSettings = window.mga_settings;",
             'before'
         );
     }

--- a/ma-galerie-automatique/uninstall.php
+++ b/ma-galerie-automatique/uninstall.php
@@ -15,6 +15,7 @@ if ( is_multisite() ) {
         switch_to_blog( $site_id );
         delete_option( 'mga_settings' );
         delete_option( 'mga_swiper_asset_sources' );
+        delete_post_meta_by_key( '_mga_has_linked_images' );
         restore_current_blog();
     }
 
@@ -23,3 +24,4 @@ if ( is_multisite() ) {
 
 delete_option( 'mga_settings' );
 delete_option( 'mga_swiper_asset_sources' );
+delete_post_meta_by_key( '_mga_has_linked_images' );


### PR DESCRIPTION
## Summary
- expose the plugin settings object on `window.mga_settings` so the frontend script can consume saved options
- also mirror the data on `window.mgaSettings` for backward compatibility
- remove the cached `_mga_has_linked_images` post meta entries during uninstall, including on multisite

## Testing
- php -l ma-galerie-automatique/ma-galerie-automatique.php
- php -l ma-galerie-automatique/uninstall.php

------
https://chatgpt.com/codex/tasks/task_e_68d42f2cbaa8832e8f3e42344e31f8b2