### PR TITLE
Improve i18n, detection performance, and admin accessibility

### DIFF
--- a/ma-galerie-automatique/assets/js/admin-script.js
+++ b/ma-galerie-automatique/assets/js/admin-script.js
@@ -26,26 +26,54 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     // Live update for range sliders
-    const thumbSizeSlider = document.getElementById('mga_thumb_size');
-    const thumbSizeValue = document.getElementById('mga_thumb_size_value');
-    const thumbSizeMobileSlider = document.getElementById('mga_thumb_size_mobile');
-    const thumbSizeMobileValue = document.getElementById('mga_thumb_size_mobile_value');
-    if (thumbSizeSlider && thumbSizeValue) {
-        thumbSizeSlider.addEventListener('input', () => {
-            thumbSizeValue.textContent = mgaAdminSprintf(mgaAdmin__('%spx', 'lightbox-jlg'), thumbSizeSlider.value);
-        });
-    }
-    if (thumbSizeMobileSlider && thumbSizeMobileValue) {
-        thumbSizeMobileSlider.addEventListener('input', () => {
-            thumbSizeMobileValue.textContent = mgaAdminSprintf(mgaAdmin__('%spx', 'lightbox-jlg'), thumbSizeMobileSlider.value);
-        });
-    }
+    const bindRangeToOutput = (sliderId, outputId, displayFormatter, ariaFormatter) => {
+        const slider = document.getElementById(sliderId);
+        const output = document.getElementById(outputId);
 
-    const opacitySlider = document.getElementById('mga_bg_opacity');
-    const opacityValue = document.getElementById('mga_bg_opacity_value');
-    if (opacitySlider && opacityValue) {
-        opacitySlider.addEventListener('input', () => {
-            opacityValue.textContent = opacitySlider.value;
-        });
-    }
+        if (!slider || !output) {
+            return;
+        }
+
+        const updateOutput = () => {
+            const value = slider.value;
+            const displayValue = typeof displayFormatter === 'function'
+                ? displayFormatter(value)
+                : value;
+            const ariaValue = typeof ariaFormatter === 'function'
+                ? ariaFormatter(value)
+                : displayValue;
+
+            if (typeof output.value !== 'undefined') {
+                output.value = displayValue;
+            }
+
+            output.textContent = displayValue;
+            slider.setAttribute('aria-valuenow', value);
+            slider.setAttribute('aria-valuetext', ariaValue);
+        };
+
+        slider.addEventListener('input', updateOutput);
+        updateOutput();
+    };
+
+    bindRangeToOutput(
+        'mga_thumb_size',
+        'mga_thumb_size_value',
+        (value) => mgaAdminSprintf(mgaAdmin__('%spx', 'lightbox-jlg'), value),
+        (value) => mgaAdminSprintf(mgaAdmin__('%s pixels', 'lightbox-jlg'), value)
+    );
+
+    bindRangeToOutput(
+        'mga_thumb_size_mobile',
+        'mga_thumb_size_mobile_value',
+        (value) => mgaAdminSprintf(mgaAdmin__('%spx', 'lightbox-jlg'), value),
+        (value) => mgaAdminSprintf(mgaAdmin__('%s pixels', 'lightbox-jlg'), value)
+    );
+
+    bindRangeToOutput(
+        'mga_bg_opacity',
+        'mga_bg_opacity_value',
+        (value) => value,
+        (value) => mgaAdminSprintf(mgaAdmin__('%s opacity', 'lightbox-jlg'), value)
+    );
 });

--- a/ma-galerie-automatique/includes/admin-page-template.php
+++ b/ma-galerie-automatique/includes/admin-page-template.php
@@ -34,12 +34,42 @@ $settings = wp_parse_args( $settings, $defaults );
                     <th scope="row"><?php echo esc_html__( 'Taille des miniatures', 'lightbox-jlg' ); ?></th>
                     <td>
                         <label for="mga_thumb_size"><?php echo esc_html__( 'PC', 'lightbox-jlg' ); ?></label><br>
-                        <input name="mga_settings[thumb_size]" type="range" id="mga_thumb_size" value="<?php echo esc_attr( $settings['thumb_size'] ); ?>" min="50" max="150" step="5" />
-                        <span id="mga_thumb_size_value"><?php printf( esc_html__( '%dpx', 'lightbox-jlg' ), intval( $settings['thumb_size'] ) ); ?></span>
+                        <input
+                            name="mga_settings[thumb_size]"
+                            type="range"
+                            id="mga_thumb_size"
+                            value="<?php echo esc_attr( $settings['thumb_size'] ); ?>"
+                            min="50"
+                            max="150"
+                            step="5"
+                            aria-valuemin="50"
+                            aria-valuemax="150"
+                            aria-valuenow="<?php echo esc_attr( $settings['thumb_size'] ); ?>"
+                            aria-valuetext="<?php echo esc_attr( sprintf( __( '%s pixels', 'lightbox-jlg' ), intval( $settings['thumb_size'] ) ) ); ?>"
+                            aria-describedby="mga_thumb_size_value"
+                        />
+                        <output id="mga_thumb_size_value" for="mga_thumb_size" class="mga-range-output" aria-live="polite">
+                            <?php printf( esc_html__( '%dpx', 'lightbox-jlg' ), intval( $settings['thumb_size'] ) ); ?>
+                        </output>
                         <br><br>
                         <label for="mga_thumb_size_mobile"><?php echo esc_html__( 'Mobile', 'lightbox-jlg' ); ?></label><br>
-                        <input name="mga_settings[thumb_size_mobile]" type="range" id="mga_thumb_size_mobile" value="<?php echo esc_attr( $settings['thumb_size_mobile'] ); ?>" min="40" max="100" step="5" />
-                        <span id="mga_thumb_size_mobile_value"><?php printf( esc_html__( '%dpx', 'lightbox-jlg' ), intval( $settings['thumb_size_mobile'] ) ); ?></span>
+                        <input
+                            name="mga_settings[thumb_size_mobile]"
+                            type="range"
+                            id="mga_thumb_size_mobile"
+                            value="<?php echo esc_attr( $settings['thumb_size_mobile'] ); ?>"
+                            min="40"
+                            max="100"
+                            step="5"
+                            aria-valuemin="40"
+                            aria-valuemax="100"
+                            aria-valuenow="<?php echo esc_attr( $settings['thumb_size_mobile'] ); ?>"
+                            aria-valuetext="<?php echo esc_attr( sprintf( __( '%s pixels', 'lightbox-jlg' ), intval( $settings['thumb_size_mobile'] ) ) ); ?>"
+                            aria-describedby="mga_thumb_size_mobile_value"
+                        />
+                        <output id="mga_thumb_size_mobile_value" for="mga_thumb_size_mobile" class="mga-range-output" aria-live="polite">
+                            <?php printf( esc_html__( '%dpx', 'lightbox-jlg' ), intval( $settings['thumb_size_mobile'] ) ); ?>
+                        </output>
                         <p class="description"><?php echo esc_html__( "Ajustez la hauteur des miniatures en bas de la galerie pour chaque type d'appareil.", 'lightbox-jlg' ); ?></p>
                     </td>
                 </tr>
@@ -53,8 +83,23 @@ $settings = wp_parse_args( $settings, $defaults );
                 <tr>
                     <th scope="row"><label for="mga_bg_opacity"><?php echo esc_html__( "Opacité de l'arrière-plan", 'lightbox-jlg' ); ?></label></th>
                     <td>
-                         <input name="mga_settings[bg_opacity]" type="range" id="mga_bg_opacity" value="<?php echo esc_attr( $settings['bg_opacity'] ); ?>" min="0.5" max="1" step="0.05" />
-                         <span id="mga_bg_opacity_value"><?php echo esc_html( $settings['bg_opacity'] ); ?></span>
+                        <input
+                            name="mga_settings[bg_opacity]"
+                            type="range"
+                            id="mga_bg_opacity"
+                            value="<?php echo esc_attr( $settings['bg_opacity'] ); ?>"
+                            min="0.5"
+                            max="1"
+                            step="0.05"
+                            aria-valuemin="0.5"
+                            aria-valuemax="1"
+                            aria-valuenow="<?php echo esc_attr( $settings['bg_opacity'] ); ?>"
+                            aria-valuetext="<?php echo esc_attr( sprintf( __( '%s opacity', 'lightbox-jlg' ), $settings['bg_opacity'] ) ); ?>"
+                            aria-describedby="mga_bg_opacity_value"
+                        />
+                        <output id="mga_bg_opacity_value" for="mga_bg_opacity" class="mga-range-output" aria-live="polite">
+                            <?php echo esc_html( $settings['bg_opacity'] ); ?>
+                        </output>
                         <p class="description"><?php echo esc_html__( "Réglez la transparence du fond de la galerie (0.5 = transparent, 1 = opaque).", 'lightbox-jlg' ); ?></p>
                     </td>
                 </tr>


### PR DESCRIPTION
## Summary
- let WordPress load translations even when the plugin languages directory is missing and reuse a shared block parsing helper during image detection
- normalise frontend settings without resanitising CSS selectors, refine selector sanitisation, and expose a filter to limit cached post types
- enhance the admin range controls with aria metadata, live outputs, and matching JavaScript helpers for improved accessibility

## Testing
- php -l ma-galerie-automatique/ma-galerie-automatique.php
- php -l ma-galerie-automatique/includes/admin-page-template.php

------
https://chatgpt.com/codex/tasks/task_e_68d436154888832eaee5f43b1846f4d9