### PR TITLE
Add tracked post type setting and improve admin accessibility

### DIFF
--- a/ma-galerie-automatique/assets/js/admin-script.js
+++ b/ma-galerie-automatique/assets/js/admin-script.js
@@ -12,16 +12,89 @@ const mgaAdminSprintf = mgaAdminI18n && typeof mgaAdminI18n.sprintf === 'functio
     };
 
 document.addEventListener('DOMContentLoaded', function() {
-    const navTabs = document.querySelectorAll('.mga-admin-wrap .nav-tab');
-    const tabContents = document.querySelectorAll('.mga-admin-wrap .tab-content');
+    const navTabs = Array.from(document.querySelectorAll('.mga-admin-wrap .nav-tab'));
+    const tabContents = Array.from(document.querySelectorAll('.mga-admin-wrap .tab-content'));
 
-    navTabs.forEach(tab => {
-        tab.addEventListener('click', function(e) {
-            e.preventDefault();
-            navTabs.forEach(t => t.classList.remove('nav-tab-active'));
-            tabContents.forEach(c => c.classList.remove('active'));
-            this.classList.add('nav-tab-active');
-            document.querySelector(this.getAttribute('href')).classList.add('active');
+    const activateTab = (tab, focusTab = true) => {
+        if (!tab) {
+            return;
+        }
+
+        navTabs.forEach((t) => {
+            t.classList.remove('nav-tab-active');
+            t.setAttribute('aria-selected', 'false');
+            t.setAttribute('tabindex', '-1');
+        });
+
+        tabContents.forEach((panel) => {
+            panel.classList.remove('active');
+            panel.setAttribute('aria-hidden', 'true');
+            panel.setAttribute('hidden', 'hidden');
+        });
+
+        tab.classList.add('nav-tab-active');
+        tab.setAttribute('aria-selected', 'true');
+        tab.setAttribute('tabindex', '0');
+
+        const targetSelector = tab.getAttribute('href');
+        const targetPanel = targetSelector ? document.querySelector(targetSelector) : null;
+
+        if (targetPanel) {
+            targetPanel.classList.add('active');
+            targetPanel.setAttribute('aria-hidden', 'false');
+            targetPanel.removeAttribute('hidden');
+        }
+
+        if (focusTab) {
+            tab.focus({ preventScroll: true });
+        }
+    };
+
+    const focusAdjacentTab = (currentTab, direction) => {
+        const currentIndex = navTabs.indexOf(currentTab);
+
+        if (currentIndex === -1) {
+            return;
+        }
+
+        const targetIndex = (currentIndex + direction + navTabs.length) % navTabs.length;
+        activateTab(navTabs[targetIndex]);
+    };
+
+    navTabs.forEach((tab) => {
+        tab.addEventListener('click', (event) => {
+            event.preventDefault();
+            activateTab(tab, false);
+        });
+
+        tab.addEventListener('keydown', (event) => {
+            switch (event.key) {
+                case 'ArrowRight':
+                case 'ArrowDown':
+                    event.preventDefault();
+                    focusAdjacentTab(tab, 1);
+                    break;
+                case 'ArrowLeft':
+                case 'ArrowUp':
+                    event.preventDefault();
+                    focusAdjacentTab(tab, -1);
+                    break;
+                case 'Home':
+                    event.preventDefault();
+                    activateTab(navTabs[0]);
+                    break;
+                case 'End':
+                    event.preventDefault();
+                    activateTab(navTabs[navTabs.length - 1]);
+                    break;
+                case ' ':
+                case 'Enter':
+                    event.preventDefault();
+                    activateTab(tab);
+                    break;
+                default:
+                    break;
+            }
         });
     });
 

--- a/ma-galerie-automatique/includes/admin-page-template.php
+++ b/ma-galerie-automatique/includes/admin-page-template.php
@@ -13,15 +13,42 @@ $settings = wp_parse_args( $settings, $defaults );
 <div class="wrap mga-admin-wrap">
     <h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
 
-    <div class="nav-tab-wrapper">
-        <a href="#settings" class="nav-tab nav-tab-active"><?php echo esc_html__( 'Réglages', 'lightbox-jlg' ); ?></a>
-        <a href="#tutorial" class="nav-tab"><?php echo esc_html__( 'Tutoriel', 'lightbox-jlg' ); ?></a>
+    <div class="nav-tab-wrapper" role="tablist" aria-label="<?php echo esc_attr__( 'Sections de la page de réglages', 'lightbox-jlg' ); ?>">
+        <a
+            href="#settings"
+            class="nav-tab nav-tab-active"
+            id="mga-tab-link-settings"
+            role="tab"
+            aria-controls="settings"
+            aria-selected="true"
+            tabindex="0"
+        >
+            <?php echo esc_html__( 'Réglages', 'lightbox-jlg' ); ?>
+        </a>
+        <a
+            href="#tutorial"
+            class="nav-tab"
+            id="mga-tab-link-tutorial"
+            role="tab"
+            aria-controls="tutorial"
+            aria-selected="false"
+            tabindex="-1"
+        >
+            <?php echo esc_html__( 'Tutoriel', 'lightbox-jlg' ); ?>
+        </a>
     </div>
 
     <form action="options.php" method="post">
         <?php settings_fields( 'mga_settings_group' ); ?>
 
-        <div id="settings" class="tab-content active">
+        <div
+            id="settings"
+            class="tab-content active"
+            role="tabpanel"
+            aria-labelledby="mga-tab-link-settings"
+            aria-hidden="false"
+            tabindex="0"
+        >
             <table class="form-table">
                 <tr>
                     <th scope="row"><label for="mga_delay"><?php echo esc_html__( 'Vitesse du diaporama', 'lightbox-jlg' ); ?></label></th>
@@ -157,10 +184,64 @@ $settings = wp_parse_args( $settings, $defaults );
                         </fieldset>
                     </td>
                 </tr>
+                <tr>
+                    <th scope="row"><?php echo esc_html__( 'Types de contenu suivis', 'lightbox-jlg' ); ?></th>
+                    <td>
+                        <fieldset>
+                            <legend class="screen-reader-text">
+                                <span><?php echo esc_html__( 'Sélectionnez les types de contenu à analyser', 'lightbox-jlg' ); ?></span>
+                            </legend>
+                            <?php
+                            $post_types = get_post_types( [ 'public' => true ], 'objects' );
+
+                            if ( empty( $post_types ) ) :
+                                ?>
+                                <p class="description"><?php echo esc_html__( 'Aucun type de contenu public n’a été détecté.', 'lightbox-jlg' ); ?></p>
+                                <?php
+                            else :
+                                foreach ( $post_types as $post_type ) :
+                                    if ( 'attachment' === $post_type->name ) {
+                                        continue;
+                                    }
+
+                                    $is_checked = in_array( $post_type->name, (array) $settings['tracked_post_types'], true );
+                                    ?>
+                                    <label for="mga-tracked-post-type-<?php echo esc_attr( $post_type->name ); ?>" class="mga-tracked-post-type">
+                                        <input
+                                            type="checkbox"
+                                            id="mga-tracked-post-type-<?php echo esc_attr( $post_type->name ); ?>"
+                                            name="mga_settings[tracked_post_types][]"
+                                            value="<?php echo esc_attr( $post_type->name ); ?>"
+                                            <?php checked( $is_checked ); ?>
+                                        />
+                                        <span><?php echo esc_html( $post_type->labels->singular_name ); ?></span>
+                                    </label>
+                                    <br />
+                                    <?php
+                                endforeach;
+
+                                ?>
+                                <p class="description">
+                                    <?php echo esc_html__( 'Limitez l’analyse aux contenus réellement utilisés pour vos galeries. Par défaut, seuls les articles et les pages sont inspectés.', 'lightbox-jlg' ); ?>
+                                </p>
+                                <?php
+                            endif;
+                            ?>
+                        </fieldset>
+                    </td>
+                </tr>
             </table>
         </div>
 
-        <div id="tutorial" class="tab-content">
+        <div
+            id="tutorial"
+            class="tab-content"
+            role="tabpanel"
+            aria-labelledby="mga-tab-link-tutorial"
+            aria-hidden="true"
+            tabindex="0"
+            hidden
+        >
             <h2><span class="dashicons dashicons-editor-help"></span> <?php echo esc_html__( 'Comment faire fonctionner la galerie ?', 'lightbox-jlg' ); ?></h2>
             <p><?php echo esc_html__( "Cette extension est conçue pour s'intégrer naturellement à WordPress. Le principe est simple : seules les images que vous décidez de lier deviendront des déclencheurs pour la galerie.", 'lightbox-jlg' ); ?></p>
             <ol style="list-style-type: decimal; margin-left: 20px;">


### PR DESCRIPTION
## Summary
- add a default set of tracked post types and expose a UI/sanitizer to control them, reducing unnecessary cache refreshes
- avoid autoloading the Swiper asset source option and expose a TTL filter for easier tuning
- add ARIA roles/keyboard support to the settings tabs for better accessibility

## Testing
- php -l ma-galerie-automatique/ma-galerie-automatique.php
- php -l ma-galerie-automatique/includes/admin-page-template.php

------
https://chatgpt.com/codex/tasks/task_e_68d44c12fd84832e860a642821f2c37f