### PR TITLE
Fix cached linked images flag casting

### DIFF
--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -366,7 +366,7 @@ function mga_get_cached_post_linked_images( WP_Post $post ) {
         return null;
     }
 
-    return (bool) $cached_value;
+    return in_array( $cached_value, [ 1, '1' ], true );
 }
 
 /**


### PR DESCRIPTION
## Summary
- ensure cached detection flag uses strict comparison when reading from post meta to respect stored `0` values

## Testing
- php -l ma-galerie-automatique/ma-galerie-automatique.php

------
https://chatgpt.com/codex/tasks/task_e_68d50a85001c832eabaf167659fcef30