### PR TITLE
Aligne les types suivis dans mga_should_enqueue_assets

### DIFF
--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -330,7 +330,8 @@ add_action( 'wp_enqueue_scripts', 'mga_enqueue_assets' );
 function mga_should_enqueue_assets( $post ) {
     $post = get_post( $post );
     $defaults = mga_get_default_settings();
-    $settings = get_option( 'mga_settings', $defaults );
+    $saved_settings = get_option( 'mga_settings', [] );
+    $settings = wp_parse_args( (array) $saved_settings, $defaults );
 
     $tracked_post_types = [];
 


### PR DESCRIPTION
## Summary
- merge les options sauvegardées avec les valeurs par défaut au début de `mga_should_enqueue_assets`
- reconstruit la liste des types de contenus suivis comme lors du rafraîchissement du cache et retourne `false` pour les contenus non suivis avant d’analyser le contenu

## Testing
- php -l ma-galerie-automatique/ma-galerie-automatique.php

------
https://chatgpt.com/codex/tasks/task_e_68d5ad472a00832eada0b4bf67ce68b9