### PR TITLE
Allow fragment identifiers in linked image detection

### DIFF
--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -550,7 +550,7 @@ function mga_detect_post_linked_images( WP_Post $post ) {
     }
 
     if ( ! $has_linked_images ) {
-        $linked_image_pattern = '#<a\b[^>]*href=["\']([^"\']+\.(?:jpe?g|png|gif|bmp|webp|avif|svg))(?:\?[^"\']*)?["\'][^>]*>\s*(?:<picture\b[^>]*>.*?<img\b[^>]*>|<img\b[^>]*>)#is';
+        $linked_image_pattern = '#<a\b[^>]*href=["\']([^"\']+\.(?:jpe?g|png|gif|bmp|webp|avif|svg))(?:\?[^"\']*)?(?:\#[^"\']*)?["\'][^>]*>\s*(?:<picture\b[^>]*>.*?<img\b[^>]*>|<img\b[^>]*>)#is';
 
         $has_anchor = false !== stripos( $content, '<a' );
         $has_media_tag = false !== stripos( $content, '<img' ) || false !== stripos( $content, '<picture' );
@@ -808,7 +808,7 @@ function mga_post_has_eligible_images( $post = null ) {
         return false;
     }
 
-    $pattern = '#<a\\b[^>]*href=["\']([^"\']+\.(?:jpe?g|png|gif|bmp|webp|avif|svg))(?:\?[^"\']*)?["\'][^>]*>\\s*(?:<picture\\b[^>]*>.*?<img\\b[^>]*>|<img\\b[^>]*>)#is';
+    $pattern = '#<a\\b[^>]*href=["\']([^"\']+\.(?:jpe?g|png|gif|bmp|webp|avif|svg))(?:\?[^"\']*)?(?:\\#[^"\']*)?["\'][^>]*>\\s*(?:<picture\\b[^>]*>.*?<img\\b[^>]*>|<img\\b[^>]*>)#is';
 
     if ( preg_match( $pattern, $content ) ) {
         return true;


### PR DESCRIPTION
## Summary
- allow fragment identifiers when scanning anchors that link to eligible image files in PHP detection routines
- keep the fallback image detection regex in sync with the primary linked image pattern

## Testing
- php /tmp/test_regex.php

------
https://chatgpt.com/codex/tasks/task_e_68d6510e2708832eb5798a50b62cbadc