### PR TITLE
Ensure swiper asset sources option autoload remains disabled

### DIFF
--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -101,7 +101,7 @@ function mga_refresh_swiper_asset_sources() {
     if ( false === $existing_sources ) {
         add_option( 'mga_swiper_asset_sources', $sources, '', 'no' );
     } else {
-        update_option( 'mga_swiper_asset_sources', $sources, false );
+        update_option( 'mga_swiper_asset_sources', $sources, 'no' );
     }
 
     return $sources;

--- a/tests/phpunit/test-swiper-asset-sources.php
+++ b/tests/phpunit/test-swiper-asset-sources.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Tests for mga_refresh_swiper_asset_sources().
+ */
+
+if ( ! function_exists( 'mga_refresh_swiper_asset_sources' ) ) {
+    require_once dirname( __DIR__ ) . '/../ma-galerie-automatique/ma-galerie-automatique.php';
+}
+
+class MGA_Swiper_Asset_Sources_Test extends WP_UnitTestCase {
+    public function test_autoload_value_remains_no_after_refresh() {
+
+        global $wpdb;
+
+        delete_option( 'mga_swiper_asset_sources' );
+        add_option( 'mga_swiper_asset_sources', [
+            'css' => 'cdn',
+            'js'  => 'cdn',
+        ], '', 'no' );
+
+        mga_refresh_swiper_asset_sources();
+
+        $autoload = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT autoload FROM {$wpdb->options} WHERE option_name = %s",
+                'mga_swiper_asset_sources'
+            )
+        );
+
+        $this->assertSame( 'no', $autoload );
+    }
+}


### PR DESCRIPTION
## Summary
- set mga_refresh_swiper_asset_sources() to always persist the option with autoload set to "no"
- add a PHPUnit test verifying the swiper asset source option retains the "no" autoload flag after refresh

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d65d69cb34832e8966aae9e9d34ae3