### PR TITLE
Add shared admin focus helper and JS tests

### DIFF
--- a/ma-galerie-automatique/assets/js/utils/focus-utils.js
+++ b/ma-galerie-automatique/assets/js/utils/focus-utils.js
@@ -1,0 +1,87 @@
+/* eslint-disable no-underscore-dangle */
+(function(global) {
+    let focusSupportsOptionsCache = null;
+
+    function detectFocusOptionsSupport() {
+        if (focusSupportsOptionsCache !== null) {
+            return focusSupportsOptionsCache;
+        }
+
+        focusSupportsOptionsCache = false;
+
+        const doc = global.document;
+
+        if (
+            !doc ||
+            typeof doc.createElement !== 'function' ||
+            typeof global.HTMLElement === 'undefined' ||
+            !global.HTMLElement.prototype ||
+            typeof global.HTMLElement.prototype.focus !== 'function'
+        ) {
+            return focusSupportsOptionsCache;
+        }
+
+        const testElement = doc.createElement('button');
+        const root = doc.body || doc.documentElement;
+
+        try {
+            testElement.type = 'button';
+
+            if (root && typeof root.appendChild === 'function') {
+                root.appendChild(testElement);
+            }
+
+            global.HTMLElement.prototype.focus.call(testElement, {
+                get preventScroll() {
+                    focusSupportsOptionsCache = true;
+                    return true;
+                },
+            });
+        } catch (error) {
+            focusSupportsOptionsCache = false;
+        } finally {
+            if (testElement.parentNode && typeof testElement.parentNode.removeChild === 'function') {
+                testElement.parentNode.removeChild(testElement);
+            }
+        }
+
+        return focusSupportsOptionsCache;
+    }
+
+    function safeFocus(element, options = { preventScroll: true }) {
+        if (!element || typeof element.focus !== 'function') {
+            return;
+        }
+
+        const canUseOptions = options && detectFocusOptionsSupport();
+
+        if (canUseOptions) {
+            try {
+                element.focus(options);
+                return;
+            } catch (error) {
+                // Ignore and fall back to focusing without options.
+            }
+        }
+
+        element.focus();
+    }
+
+    const focusUtils = {
+        detectFocusOptionsSupport,
+        safeFocus,
+    };
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = focusUtils;
+    }
+
+    if (global && typeof global === 'object') {
+        if (!global.mgaFocusUtils || typeof global.mgaFocusUtils !== 'object') {
+            global.mgaFocusUtils = {};
+        }
+
+        global.mgaFocusUtils.detectFocusOptionsSupport = detectFocusOptionsSupport;
+        global.mgaFocusUtils.safeFocus = safeFocus;
+    }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -1014,7 +1014,21 @@ function mga_admin_enqueue_assets($hook) {
     if ( ! current_user_can( 'manage_options' ) ) return;
     if ($hook !== 'toplevel_page_ma-galerie-automatique') return;
     wp_enqueue_style('mga-admin-style', plugin_dir_url(__FILE__) . 'assets/css/admin-style.css', [], MGA_VERSION);
-    wp_register_script('mga-admin-script', plugin_dir_url(__FILE__) . 'assets/js/admin-script.js', [ 'wp-i18n' ], MGA_VERSION, true);
+    wp_register_script(
+        'mga-focus-utils',
+        plugin_dir_url(__FILE__) . 'assets/js/utils/focus-utils.js',
+        [],
+        MGA_VERSION,
+        true
+    );
+    wp_register_script(
+        'mga-admin-script',
+        plugin_dir_url(__FILE__) . 'assets/js/admin-script.js',
+        [ 'wp-i18n', 'mga-focus-utils' ],
+        MGA_VERSION,
+        true
+    );
+    wp_enqueue_script('mga-focus-utils');
     wp_enqueue_script('mga-admin-script');
     if ( mga_languages_directory_exists() ) {
         wp_set_script_translations( 'mga-admin-script', 'lightbox-jlg', mga_get_languages_path() );

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ma-galerie-automatique-jlg",
   "private": true,
   "scripts": {
+    "test": "npm run test:js",
     "test:js": "wp-scripts test-unit-js"
   },
   "devDependencies": {

--- a/tests/js/admin-script.test.js
+++ b/tests/js/admin-script.test.js
@@ -2,48 +2,31 @@
  * @jest-environment jsdom
  */
 
-describe('safeFocus helper', () => {
+describe('focus utils safeFocus helper', () => {
     let safeFocus;
-    let originalFocus;
 
     beforeEach(() => {
         jest.resetModules();
-        ({ safeFocus } = require('../../ma-galerie-automatique/assets/js/admin-script'));
-        originalFocus = HTMLElement.prototype.focus;
+        ({ safeFocus } = require('../../ma-galerie-automatique/assets/js/utils/focus-utils'));
     });
 
     afterEach(() => {
-        HTMLElement.prototype.focus = originalFocus;
+        jest.restoreAllMocks();
     });
 
     it('falls back to calling focus without options when options cause an error', () => {
-        const fallbackSpy = jest.fn();
-
-        const mockFocus = jest.fn(function(options) {
-            if (arguments.length === 0) {
-                fallbackSpy();
-                return;
+        const focusSpy = jest.spyOn(HTMLElement.prototype, 'focus').mockImplementation(function() {
+            if (arguments.length > 0) {
+                throw new TypeError('Focus options are not supported');
             }
-
-            const descriptor = options ? Object.getOwnPropertyDescriptor(options, 'preventScroll') : null;
-
-            if (descriptor && typeof descriptor.get === 'function') {
-                descriptor.get.call(options);
-                return;
-            }
-
-            throw new TypeError('Focus options are not supported');
         });
-
-        HTMLElement.prototype.focus = mockFocus;
 
         const element = document.createElement('button');
 
         expect(() => safeFocus(element, { preventScroll: true })).not.toThrow();
 
-        expect(mockFocus.mock.calls.some((call) => call.length > 0)).toBe(true);
-        const lastCallArgs = mockFocus.mock.calls[mockFocus.mock.calls.length - 1] || [];
-        expect(lastCallArgs.length).toBe(0);
-        expect(fallbackSpy).toHaveBeenCalledTimes(1);
+        expect(focusSpy).toHaveBeenCalledTimes(2);
+        expect(focusSpy.mock.calls[0].length).toBe(1);
+        expect(focusSpy.mock.calls[1].length).toBe(0);
     });
 });


### PR DESCRIPTION
## Summary
- extract the focus options helper into a reusable module consumed by the admin script
- enqueue the helper for the admin page and expose a top-level npm test script
- update the Jest suite to cover the safe focus fallback when options are unsupported

## Testing
- npm run test:js

------
https://chatgpt.com/codex/tasks/task_e_68d675b25604832eb156864b8b87981c