### PR TITLE
Add tests for swiper asset refresh on plugin upgrades

### DIFF
--- a/tests/phpunit/test-swiper-asset-sources.php
+++ b/tests/phpunit/test-swiper-asset-sources.php
@@ -7,7 +7,18 @@ if ( ! function_exists( 'mga_refresh_swiper_asset_sources' ) ) {
     require_once dirname( __DIR__ ) . '/../ma-galerie-automatique/ma-galerie-automatique.php';
 }
 
+if ( ! function_exists( 'plugin_basename' ) ) {
+    require_once ABSPATH . 'wp-admin/includes/plugin.php';
+}
+
 class MGA_Swiper_Asset_Sources_Test extends WP_UnitTestCase {
+
+    protected function tearDown(): void {
+        delete_option( 'mga_swiper_asset_sources' );
+
+        parent::tearDown();
+    }
+
     public function test_autoload_value_remains_no_after_refresh() {
 
         global $wpdb;
@@ -28,5 +39,67 @@ class MGA_Swiper_Asset_Sources_Test extends WP_UnitTestCase {
         );
 
         $this->assertSame( 'no', $autoload );
+    }
+
+    public function test_swiper_sources_refreshed_when_plugin_in_upgrade_batch() {
+        global $wpdb;
+
+        $plugin_basename = plugin_basename( dirname( __DIR__ ) . '/ma-galerie-automatique/ma-galerie-automatique.php' );
+        $sentinel = [
+            'css'        => 'cdn',
+            'js'         => 'cdn',
+            'checked_at' => 1,
+        ];
+
+        delete_option( 'mga_swiper_asset_sources' );
+        add_option( 'mga_swiper_asset_sources', $sentinel, '', 'no' );
+
+        do_action(
+            'upgrader_process_complete',
+            new stdClass(),
+            [
+                'type'    => 'plugin',
+                'plugins' => [ $plugin_basename ],
+            ]
+        );
+
+        $sources = get_option( 'mga_swiper_asset_sources' );
+
+        $this->assertIsArray( $sources );
+        $this->assertArrayHasKey( 'checked_at', $sources );
+        $this->assertGreaterThan( $sentinel['checked_at'], $sources['checked_at'] );
+
+        $autoload = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT autoload FROM {$wpdb->options} WHERE option_name = %s",
+                'mga_swiper_asset_sources'
+            )
+        );
+
+        $this->assertSame( 'no', $autoload );
+    }
+
+    public function test_swiper_sources_not_refreshed_when_plugin_not_in_upgrade_batch() {
+        $sentinel = [
+            'css'        => 'cdn',
+            'js'         => 'cdn',
+            'checked_at' => 1,
+        ];
+
+        delete_option( 'mga_swiper_asset_sources' );
+        add_option( 'mga_swiper_asset_sources', $sentinel, '', 'no' );
+
+        do_action(
+            'upgrader_process_complete',
+            new stdClass(),
+            [
+                'type'    => 'plugin',
+                'plugins' => [ 'another-plugin/another-plugin.php' ],
+            ]
+        );
+
+        $sources = get_option( 'mga_swiper_asset_sources' );
+
+        $this->assertSame( $sentinel, $sources );
     }
 }


### PR DESCRIPTION
## Summary
- load plugin helpers in the swiper asset test suite and clean the option between tests
- cover the upgrader_process_complete hook refreshing swiper sources when the plugin is updated
- assert the hook skips refreshing when the plugin is not part of the upgrade batch

## Testing
- phpunit *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d69f480cb4832e9546ca30225c0189