### PR TITLE
Add password-protected guard to asset enqueue logic

### DIFF
--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -329,6 +329,11 @@ add_action( 'wp_enqueue_scripts', 'mga_enqueue_assets' );
  */
 function mga_should_enqueue_assets( $post ) {
     $post = get_post( $post );
+
+    if ( post_password_required( $post ) ) {
+        return false;
+    }
+
     $defaults = mga_get_default_settings();
     $saved_settings = get_option( 'mga_settings', [] );
     $settings = wp_parse_args( (array) $saved_settings, $defaults );

--- a/tests/phpunit/EnqueueEligibilityTest.php
+++ b/tests/phpunit/EnqueueEligibilityTest.php
@@ -161,6 +161,26 @@ class EnqueueEligibilityTest extends WP_UnitTestCase {
     }
 
     /**
+     * Password protected posts should not enqueue assets until unlocked by the visitor.
+     */
+    public function test_password_protected_posts_require_unlocked_access() {
+        $post_id = self::factory()->post->create(
+            [
+                'post_content'  => '<a href="https://example.com/image.jpg"><img src="https://example.com/image.jpg" /></a>',
+                'post_password' => 'secret',
+            ]
+        );
+
+        $this->go_to( get_permalink( $post_id ) );
+
+        $cookie_key = 'wp-postpass_' . COOKIEHASH;
+        unset( $_COOKIE[ $cookie_key ] );
+
+        $this->assertTrue( post_password_required( $post_id ), 'Visiting a protected post without the access cookie should still require the password.' );
+        $this->assertFalse( mga_should_enqueue_assets( $post_id ), 'Assets should not enqueue for locked password protected posts.' );
+    }
+
+    /**
      * Registers a public post type for test scenarios and tracks it for tearDown cleanup.
      *
      * @param string $post_type Custom post type slug.


### PR DESCRIPTION
## Summary
- prevent `mga_should_enqueue_assets()` from enqueuing assets when a post is still password locked
- add unit coverage ensuring password-protected posts bail out until unlocked

## Testing
- `phpunit` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7cfffc570832eaec7124d9d6ce9de