### PR TITLE
Respect password protection when enqueuing assets

### DIFF
--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -329,6 +329,9 @@ add_action( 'wp_enqueue_scripts', 'mga_enqueue_assets' );
  */
 function mga_should_enqueue_assets( $post ) {
     $post = get_post( $post );
+    if ( $post instanceof WP_Post && post_password_required( $post ) ) {
+        return false;
+    }
     $defaults = mga_get_default_settings();
     $saved_settings = get_option( 'mga_settings', [] );
     $settings = wp_parse_args( (array) $saved_settings, $defaults );

--- a/tests/phpunit/EnqueueEligibilityTest.php
+++ b/tests/phpunit/EnqueueEligibilityTest.php
@@ -160,6 +160,26 @@ class EnqueueEligibilityTest extends WP_UnitTestCase {
         remove_filter( 'mga_force_enqueue', '__return_true' );
     }
 
+    public function test_password_protected_posts_are_ignored_until_unlocked() {
+        $linked_image_markup = '<a href="https://example.com/image.jpg"><img src="https://example.com/image.jpg" /></a>';
+        $post_id             = self::factory()->post->create(
+            [
+                'post_content'   => $linked_image_markup,
+                'post_password'  => 'secret',
+                'comment_status' => 'closed',
+            ]
+        );
+
+        unset( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] );
+
+        $this->go_to( get_permalink( $post_id ) );
+
+        $this->assertFalse(
+            mga_should_enqueue_assets( $post_id ),
+            'Password protected posts should not enqueue assets before the password is provided.'
+        );
+    }
+
     /**
      * Registers a public post type for test scenarios and tracks it for tearDown cleanup.
      *


### PR DESCRIPTION
## Summary
- ensure mga_should_enqueue_assets() bails out for password-protected posts until unlocked
- add PHPUnit coverage for the password-protected post scenario

## Testing
- not run (phpunit unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7d2a58b54832ea41a866c0eac3ab6