### PR TITLE
Prevent layout shift when locking body scroll

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -35,6 +35,7 @@
         let isResizeListenerAttached = false;
         let initialBodyOverflow = null;
         let bodyOverflowWasModified = false;
+        let initialBodyPaddingRight = null;
         let lastFocusedElementBeforeViewer = null;
         let viewerFocusTrapHandler = null;
 
@@ -991,6 +992,23 @@
                 setupViewerFocusManagement(viewer);
                 const previousOverflow = document.body.style.overflow;
                 initialBodyOverflow = previousOverflow;
+                initialBodyPaddingRight = document.body.style.paddingRight;
+                const docEl = document.documentElement;
+                if (typeof window !== 'undefined' && docEl) {
+                    const computedScrollbarWidth = Math.max(window.innerWidth - docEl.clientWidth, 0);
+                    if (computedScrollbarWidth > 0) {
+                        let basePadding = 0;
+                        try {
+                            const computedStyle = window.getComputedStyle(document.body);
+                            const parsedPadding = parseFloat(computedStyle.paddingRight || '0');
+                            basePadding = Number.isNaN(parsedPadding) ? 0 : parsedPadding;
+                        } catch (styleError) {
+                            const parsedInline = parseFloat(initialBodyPaddingRight || '0');
+                            basePadding = Number.isNaN(parsedInline) ? 0 : parsedInline;
+                        }
+                        document.body.style.paddingRight = `${basePadding + computedScrollbarWidth}px`;
+                    }
+                }
                 if (previousOverflow !== 'hidden') {
                     document.body.style.overflow = 'hidden';
                     bodyOverflowWasModified = true;
@@ -1287,8 +1305,14 @@
             if (bodyOverflowWasModified) {
                 document.body.style.overflow = initialBodyOverflow;
             }
+            if (typeof initialBodyPaddingRight === 'string') {
+                document.body.style.paddingRight = initialBodyPaddingRight;
+            } else {
+                document.body.style.paddingRight = '';
+            }
             initialBodyOverflow = null;
             bodyOverflowWasModified = false;
+            initialBodyPaddingRight = null;
             debug.log(mga__( 'Galerie fermée.', 'lightbox-jlg' ));
             debug.stopTimer();
             if (lastFocusedElementBeforeViewer && typeof lastFocusedElementBeforeViewer.focus === 'function') {


### PR DESCRIPTION
## Summary
- compensate for the missing scrollbar when opening the gallery viewer by adding temporary body padding and restoring it on close
- keep the original overflow and padding values so that the page returns to its initial scroll state when the viewer exits
- extend the Playwright end-to-end test to assert that opening the viewer does not cause a layout shift and that styles are restored after closing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d7d2a573f8832eba1e330040ad8124