### PR TITLE
Preserve autoload flag when refreshing swiper sources

### DIFF
--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -101,7 +101,7 @@ function mga_refresh_swiper_asset_sources() {
     if ( false === $existing_sources ) {
         add_option( 'mga_swiper_asset_sources', $sources, '', 'no' );
     } else {
-        update_option( 'mga_swiper_asset_sources', $sources, 'no' );
+        update_option( 'mga_swiper_asset_sources', $sources );
     }
 
     return $sources;


### PR DESCRIPTION
## Summary
- update the swiper asset refresh logic to avoid overriding the existing autoload flag when persisting the option

## Testing
- vendor/bin/phpunit --filter MGA_Swiper_Asset_Sources_Test *(fails: vendor/bin/phpunit not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8074d7100832eb73ce2f2b9ef73de