### PR TITLE
Handle forced enqueues when no global post exists

### DIFF
--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -330,6 +330,12 @@ add_action( 'wp_enqueue_scripts', 'mga_enqueue_assets' );
 function mga_should_enqueue_assets( $post ) {
     $post = get_post( $post );
 
+    $force_enqueue = apply_filters( 'mga_force_enqueue', false, $post );
+
+    if ( ! $post instanceof WP_Post ) {
+        return (bool) $force_enqueue;
+    }
+
     if ( post_password_required( $post ) ) {
         return false;
     }
@@ -359,18 +365,12 @@ function mga_should_enqueue_assets( $post ) {
     $tracked_post_types = apply_filters( 'mga_tracked_post_types', $tracked_post_types, $post );
     $tracked_post_types = array_values( array_filter( (array) $tracked_post_types ) );
 
-    $force_enqueue = apply_filters( 'mga_force_enqueue', false, $post );
-
     if ( ! is_singular() && ! $force_enqueue ) {
         return false;
     }
 
     if ( $force_enqueue ) {
         return true;
-    }
-
-    if ( ! $post instanceof WP_Post ) {
-        return false;
     }
 
     if (

--- a/tests/phpunit/EnqueueEligibilityTest.php
+++ b/tests/phpunit/EnqueueEligibilityTest.php
@@ -161,6 +161,25 @@ class EnqueueEligibilityTest extends WP_UnitTestCase {
     }
 
     /**
+     * Forcing an enqueue on non singular views without a global WP_Post should not trigger notices.
+     */
+    public function test_force_enqueue_without_global_post_object() {
+        $this->go_to( home_url( '/' ) );
+
+        $previous_global_post = $GLOBALS['post'] ?? null;
+        $GLOBALS['post']      = null;
+
+        add_filter( 'mga_force_enqueue', '__return_true' );
+
+        try {
+            $this->assertTrue( mga_should_enqueue_assets( null ), 'Forced enqueues should succeed even when no global post is available.' );
+        } finally {
+            remove_filter( 'mga_force_enqueue', '__return_true' );
+            $GLOBALS['post'] = $previous_global_post;
+        }
+    }
+
+    /**
      * Password protected posts should not enqueue assets until unlocked by the visitor.
      */
     public function test_password_protected_posts_require_unlocked_access() {


### PR DESCRIPTION
## Summary
- reorder mga_should_enqueue_assets() to evaluate the force enqueue flag before additional guards
- short-circuit early when no WP_Post is available and keep remaining checks behind a valid post instance
- add a regression test ensuring forced enqueues succeed on non-singular views without a global post

## Testing
- not run (phpunit binary unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8366df9d0832eb886bf8137adc938