### PR TITLE
Handle forced enqueue without global post object

### DIFF
--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -328,7 +328,12 @@ add_action( 'wp_enqueue_scripts', 'mga_enqueue_assets' );
  * @return bool
  */
 function mga_should_enqueue_assets( $post ) {
-    $post = get_post( $post );
+    $post           = get_post( $post );
+    $force_enqueue  = apply_filters( 'mga_force_enqueue', false, $post );
+
+    if ( ! $post instanceof WP_Post ) {
+        return (bool) $force_enqueue;
+    }
 
     if ( post_password_required( $post ) ) {
         return false;
@@ -359,18 +364,12 @@ function mga_should_enqueue_assets( $post ) {
     $tracked_post_types = apply_filters( 'mga_tracked_post_types', $tracked_post_types, $post );
     $tracked_post_types = array_values( array_filter( (array) $tracked_post_types ) );
 
-    $force_enqueue = apply_filters( 'mga_force_enqueue', false, $post );
-
     if ( ! is_singular() && ! $force_enqueue ) {
         return false;
     }
 
     if ( $force_enqueue ) {
         return true;
-    }
-
-    if ( ! $post instanceof WP_Post ) {
-        return false;
     }
 
     if (

--- a/tests/phpunit/EnqueueEligibilityTest.php
+++ b/tests/phpunit/EnqueueEligibilityTest.php
@@ -161,6 +161,26 @@ class EnqueueEligibilityTest extends WP_UnitTestCase {
     }
 
     /**
+     * Forcing the enqueue on non-singular requests without a global post should not trigger notices or fatals.
+     */
+    public function test_force_enqueue_without_global_post_does_not_error() {
+        $this->go_to( home_url( '/' ) );
+
+        unset( $GLOBALS['post'] );
+
+        add_filter( 'mga_force_enqueue', '__return_true' );
+
+        try {
+            $this->assertTrue(
+                mga_should_enqueue_assets( null ),
+                'Forced enqueue should succeed even when no global post object is available.'
+            );
+        } finally {
+            remove_filter( 'mga_force_enqueue', '__return_true' );
+        }
+    }
+
+    /**
      * Password protected posts should not enqueue assets until unlocked by the visitor.
      */
     public function test_password_protected_posts_require_unlocked_access() {


### PR DESCRIPTION
## Summary
- compute the mga_force_enqueue flag before any password checks and bail early when no WP_Post exists
- leave the remaining eligibility logic gated behind a valid post instance
- cover forced enqueues without a global post in the PHPUnit suite to guard against regressions

## Testing
- phpunit -c phpunit.xml.dist *(fails: phpunit binary is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d83670c954832e87fa737e4145800f