### PR TITLE
Add SRI metadata for Swiper CDN assets

### DIFF
--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -44,6 +44,24 @@ if ( ! defined( 'MGA_ADMIN_TEMPLATE_PATH' ) ) {
 }
 
 /**
+ * SHA-384 integrity hash for the Swiper v11.1.4 CSS bundle.
+ *
+ * Update alongside Swiper version bumps.
+ */
+if ( ! defined( 'MGA_SWIPER_CSS_SRI_HASH' ) ) {
+    define( 'MGA_SWIPER_CSS_SRI_HASH', 'sha384-PVSiG5fugGA8MJ63B59UwXZo2CdlhrZb9vyPsW2ewxr0s5WHXWgEnS+8vtFkDr7O' );
+}
+
+/**
+ * SHA-384 integrity hash for the Swiper v11.1.4 JavaScript bundle.
+ *
+ * Update alongside Swiper version bumps.
+ */
+if ( ! defined( 'MGA_SWIPER_JS_SRI_HASH' ) ) {
+    define( 'MGA_SWIPER_JS_SRI_HASH', 'sha384-ChaDfAcubhQlVCLEzy7y8vgjNLbZ4RlIjH2jjcUXjYpn0MwZieWBjpXFMjMx8Dax' );
+}
+
+/**
  * Initialise la traduction du plugin.
  */
 function mga_load_textdomain() {
@@ -248,7 +266,18 @@ function mga_enqueue_assets() {
     $swiper_js = apply_filters( 'mga_swiper_js', $swiper_js, $swiper_version );
 
     wp_enqueue_style( 'mga-swiper-css', $swiper_css, [], $swiper_version );
+
+    if ( 'cdn' === $asset_sources['css'] ) {
+        wp_style_add_data( 'mga-swiper-css', 'integrity', MGA_SWIPER_CSS_SRI_HASH );
+        wp_style_add_data( 'mga-swiper-css', 'crossorigin', 'anonymous' );
+    }
+
     wp_enqueue_script( 'mga-swiper-js', $swiper_js, [], $swiper_version, true );
+
+    if ( 'cdn' === $asset_sources['js'] ) {
+        wp_script_add_data( 'mga-swiper-js', 'integrity', MGA_SWIPER_JS_SRI_HASH );
+        wp_script_add_data( 'mga-swiper-js', 'crossorigin', 'anonymous' );
+    }
 
     // Fichiers du plugin
     wp_enqueue_style('mga-gallery-style', plugin_dir_url( __FILE__ ) . 'assets/css/gallery-slideshow.css', [], MGA_VERSION);

--- a/tests/phpunit/EnqueueAssetsTest.php
+++ b/tests/phpunit/EnqueueAssetsTest.php
@@ -21,6 +21,51 @@ class EnqueueAssetsTest extends WP_UnitTestCase {
     }
 
     /**
+     * Ensures Swiper assets loaded from the CDN receive SRI and crossorigin metadata.
+     */
+    public function test_enqueue_sets_integrity_attributes_for_cdn_swiper_assets() {
+        $post_id = self::factory()->post->create(
+            [
+                'post_content' => '<!-- wp:paragraph --><p>Content</p><!-- /wp:paragraph -->',
+            ]
+        );
+
+        $this->go_to( get_permalink( $post_id ) );
+
+        update_option(
+            'mga_swiper_asset_sources',
+            [
+                'css'        => 'cdn',
+                'js'         => 'cdn',
+                'checked_at' => time(),
+            ]
+        );
+
+        mga_enqueue_assets();
+
+        $this->assertSame(
+            MGA_SWIPER_CSS_SRI_HASH,
+            wp_styles()->get_data( 'mga-swiper-css', 'integrity' ),
+            'The Swiper CSS handle should declare the expected SRI hash when loading from the CDN.'
+        );
+        $this->assertSame(
+            'anonymous',
+            wp_styles()->get_data( 'mga-swiper-css', 'crossorigin' ),
+            'The Swiper CSS handle should set crossorigin metadata when loading from the CDN.'
+        );
+        $this->assertSame(
+            MGA_SWIPER_JS_SRI_HASH,
+            wp_scripts()->get_data( 'mga-swiper-js', 'integrity' ),
+            'The Swiper JS handle should declare the expected SRI hash when loading from the CDN.'
+        );
+        $this->assertSame(
+            'anonymous',
+            wp_scripts()->get_data( 'mga-swiper-js', 'crossorigin' ),
+            'The Swiper JS handle should set crossorigin metadata when loading from the CDN.'
+        );
+    }
+
+    /**
      * Ensures inline assets consume the sanitized settings to guard regressions in the enqueue pipeline.
      */
     public function test_enqueue_clamps_and_reflects_settings() {


### PR DESCRIPTION
## Summary
- define documented SHA-384 integrity hashes for the bundled Swiper v11.1.4 assets
- add Subresource Integrity and crossorigin metadata when Swiper assets load from the CDN
- cover the CDN code path with a PHPUnit test to guard the new attributes

## Testing
- ⚠️ `phpunit` *(fails: command not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d91e175710832ebe90bf0a94746f55