### PR TITLE
Affiche les notifications de réglages

### DIFF
--- a/ma-galerie-automatique/includes/admin-page-template.php
+++ b/ma-galerie-automatique/includes/admin-page-template.php
@@ -12,6 +12,7 @@ $settings = wp_parse_args( $settings, $defaults );
 ?>
 <div class="wrap mga-admin-wrap">
     <h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+    <?php settings_errors( 'mga_settings_group' ); ?>
 
     <div class="nav-tab-wrapper" role="tablist" aria-label="<?php echo esc_attr__( 'Sections de la page de réglages', 'lightbox-jlg' ); ?>">
         <a


### PR DESCRIPTION
## Summary
- affiche les notifications de réglages WordPress sur la page d’options de la galerie

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da573a9704832e9f6916f936ab2130