### PR TITLE
Remplacer les images de test debug par des data URI

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -800,8 +800,16 @@
         debug.onForceOpen(() => {
             debug.log(mga__( "Clic sur 'Forcer l'ouverture'.", 'lightbox-jlg' ));
             const testImages = [
-                { highResUrl: 'https://placehold.co/800x600/0073aa/ffffff?text=Image+Test+1', thumbUrl: 'https://placehold.co/150x150/0073aa/ffffff?text=Thumb+1', caption: mga__( 'Ceci est la première image de test.', 'lightbox-jlg' ) },
-                { highResUrl: 'https://placehold.co/800x600/F44336/ffffff?text=Image+Test+2', thumbUrl: 'https://placehold.co/150x150/F44336/ffffff?text=Thumb+2', caption: mga__( 'Ceci est la seconde image de test.', 'lightbox-jlg' ) }
+                {
+                    highResUrl: 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20800%20600%22%3E%3Crect%20width%3D%22800%22%20height%3D%22600%22%20fill%3D%22%230073aa%22%2F%3E%3Ctext%20x%3D%2250%25%22%20y%3D%2250%25%22%20dominant-baseline%3D%22middle%22%20text-anchor%3D%22middle%22%20font-size%3D%2248%22%20fill%3D%22%23ffffff%22%3EImage%20Test%201%3C%2Ftext%3E%3C%2Fsvg%3E',
+                    thumbUrl: 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20150%20150%22%3E%3Crect%20width%3D%22150%22%20height%3D%22150%22%20fill%3D%22%230073aa%22%2F%3E%3Ctext%20x%3D%2250%25%22%20y%3D%2250%25%22%20dominant-baseline%3D%22middle%22%20text-anchor%3D%22middle%22%20font-size%3D%2218%22%20fill%3D%22%23ffffff%22%3EThumb%201%3C%2Ftext%3E%3C%2Fsvg%3E',
+                    caption: mga__( 'Ceci est la première image de test.', 'lightbox-jlg' ),
+                },
+                {
+                    highResUrl: 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20800%20600%22%3E%3Cdefs%3E%3ClinearGradient%20id%3D%22grad%22%20x1%3D%220%25%22%20y1%3D%220%25%22%20x2%3D%22100%25%22%20y2%3D%22100%25%22%3E%3Cstop%20offset%3D%220%25%22%20stop-color%3D%22%23f44336%22%2F%3E%3Cstop%20offset%3D%22100%25%22%20stop-color%3D%22%23ff9800%22%2F%3E%3C%2FlinearGradient%3E%3C%2Fdefs%3E%3Crect%20width%3D%22800%22%20height%3D%22600%22%20fill%3D%22url(%23grad)%22%2F%3E%3Ctext%20x%3D%2250%25%22%20y%3D%2250%25%22%20dominant-baseline%3D%22middle%22%20text-anchor%3D%22middle%22%20font-size%3D%2248%22%20fill%3D%22%23ffffff%22%3EImage%20Test%202%3C%2Ftext%3E%3C%2Fsvg%3E',
+                    thumbUrl: 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20150%20150%22%3E%3Cdefs%3E%3ClinearGradient%20id%3D%22gradThumb%22%20x1%3D%220%25%22%20y1%3D%220%25%22%20x2%3D%22100%25%22%20y2%3D%22100%25%22%3E%3Cstop%20offset%3D%220%25%22%20stop-color%3D%22%23f44336%22%2F%3E%3Cstop%20offset%3D%22100%25%22%20stop-color%3D%22%23ff9800%22%2F%3E%3C%2FlinearGradient%3E%3C%2Fdefs%3E%3Crect%20width%3D%22150%22%20height%3D%22150%22%20fill%3D%22url(%23gradThumb)%22%2F%3E%3Ctext%20x%3D%2250%25%22%20y%3D%2250%25%22%20dominant-baseline%3D%22middle%22%20text-anchor%3D%22middle%22%20font-size%3D%2218%22%20fill%3D%22%23ffffff%22%3EThumb%202%3C%2Ftext%3E%3C%2Fsvg%3E',
+                    caption: mga__( 'Ceci est la seconde image de test.', 'lightbox-jlg' ),
+                },
             ];
             const previouslyFocusedElement = document.activeElement;
             lastFocusedElementBeforeViewer = previouslyFocusedElement;


### PR DESCRIPTION
## Summary
- remplacer les URL externes des images de test du mode debug par des SVG encodés en data URI pour supprimer les requêtes sortantes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da62920550832eb112c87ccf3c6080