### PR TITLE
Handle attachment links in gallery viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ La visionneuse plein écran pilotée par `assets/js/gallery-slideshow.js` et mis
 - **Navigation clavier et commandes rapides** : les flèches du clavier, les boutons latéraux et les interactions tactiles permettent d’avancer ou de reculer, même en mode boucle.
 - **Miniatures synchronisées** : un carrousel de vignettes met en évidence la diapositive active et permet de changer d’image d’un clic ou d’un tap.
 - **Arrière-plan immersif et préchargement** : un effet d’écho flouté anime le fond tandis que les visuels suivants sont préchargés pour fluidifier la lecture.
+- **Compatibilité avec les pièces jointes WordPress** : les galeries configurées avec `linkDestination: "attachment"` ouvrent la visionneuse sur le média original en s’appuyant sur les attributs `data-full-url` / `data-orig-file` des images.
 
 ### Mode débogage
 - **Activation** : cochez **Activer le mode débogage** dans les réglages du plugin (onglet **Réglages → Ma Galerie Automatique**), case ajoutée par `includes/admin-page-template.php`.

--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -278,10 +278,38 @@
                 if (linkElement.dataset.mgaHighres) {
                     return true;
                 }
+                const linkType = linkElement.dataset.type || linkElement.dataset.wpType;
+                if (typeof linkType === 'string' && linkType.toLowerCase() === 'attachment') {
+                    return true;
+                }
             }
             const rel = linkElement.getAttribute('rel');
             if (rel && rel.split(/\s+/).includes('mga-allow-fallback')) {
                 return true;
+            }
+            const dataType = linkElement.getAttribute('data-type');
+            if (typeof dataType === 'string' && dataType.toLowerCase() === 'attachment') {
+                return true;
+            }
+            const href = linkElement.getAttribute('href');
+            if (typeof href === 'string') {
+                if (/[?&]attachment_id=\d+/i.test(href)) {
+                    return true;
+                }
+                if (/\/attachment\//i.test(href)) {
+                    return true;
+                }
+                try {
+                    const baseHref = (typeof window !== 'undefined' && window.location)
+                        ? window.location.href
+                        : undefined;
+                    const url = new URL(href, baseHref);
+                    if (url.searchParams && url.searchParams.has('attachment_id')) {
+                        return true;
+                    }
+                } catch (error) {
+                    // Ignored : l'URL relative sera déjà couverte par les expressions régulières ci-dessus.
+                }
             }
             return false;
         }


### PR DESCRIPTION
## Summary
- allow gallery fallback for core/gallery attachment links and pull the high-resolution URL from image data attributes
- extend the Playwright fixture helpers and add an attachment gallery scenario to cover the viewer behaviour
- document attachment link support in the README

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dbfb941144832e84acdcc61819c3fe