### PR TITLE
Scope gallery navigation by group

### DIFF
--- a/ma-galerie-automatique/includes/admin-page-template.php
+++ b/ma-galerie-automatique/includes/admin-page-template.php
@@ -143,6 +143,21 @@ $settings = wp_parse_args( $settings, $defaults );
                     </td>
                 </tr>
                 <tr>
+                    <th scope="row"><label for="mga_group_attribute"><?php echo esc_html__( 'Attribut de regroupement', 'lightbox-jlg' ); ?></label></th>
+                    <td>
+                        <input
+                            name="mga_settings[groupAttribute]"
+                            type="text"
+                            id="mga_group_attribute"
+                            value="<?php echo esc_attr( $settings['groupAttribute'] ); ?>"
+                            class="regular-text"
+                        />
+                        <p class="description">
+                            <?php echo esc_html__( 'Indiquez l’attribut HTML qui identifie les groupes (ex. data-mga-gallery, rel, href). Laissez vide pour conserver un groupe unique comme dans les versions précédentes.', 'lightbox-jlg' ); ?>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
                     <th scope="row"><label for="mga_z_index"><?php echo esc_html__( 'Z-index de la galerie', 'lightbox-jlg' ); ?></label></th>
                     <td>
                         <input name="mga_settings[z_index]" type="number" id="mga_z_index" value="<?php echo esc_attr( $settings['z_index'] ); ?>" min="1" class="small-text" />

--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -1043,6 +1043,7 @@ function mga_get_default_settings() {
         'background_style' => 'echo',
         'z_index' => 99999,
         'debug_mode' => false,
+        'groupAttribute' => 'data-mga-gallery',
         'contentSelectors' => [],
         'allowBodyFallback' => false,
         'tracked_post_types' => [ 'post', 'page' ],
@@ -1100,6 +1101,29 @@ function mga_sanitize_settings( $input, $existing_settings = null ) {
     $output['loop'] = ! empty( $input['loop'] );
     $output['autoplay_start'] = ! empty( $input['autoplay_start'] );
     
+    $sanitize_group_attribute = static function( $value ) use ( $defaults ) {
+        if ( ! is_string( $value ) ) {
+            return $defaults['groupAttribute'];
+        }
+
+        $trimmed = trim( $value );
+        if ( '' === $trimmed ) {
+            return '';
+        }
+
+        $sanitized = strtolower( preg_replace( '/[^a-z0-9_:\-]/i', '', $trimmed ) );
+
+        return '' === $sanitized ? $defaults['groupAttribute'] : $sanitized;
+    };
+
+    if ( array_key_exists( 'groupAttribute', $input ) ) {
+        $output['groupAttribute'] = $sanitize_group_attribute( $input['groupAttribute'] );
+    } elseif ( isset( $existing_settings['groupAttribute'] ) ) {
+        $output['groupAttribute'] = $sanitize_group_attribute( $existing_settings['groupAttribute'] );
+    } else {
+        $output['groupAttribute'] = $defaults['groupAttribute'];
+    }
+
     $allowed_bg_styles = ['echo', 'blur', 'texture'];
     $output['background_style'] = isset($input['background_style']) && in_array($input['background_style'], $allowed_bg_styles, true) ? $input['background_style'] : $defaults['background_style'];
     


### PR DESCRIPTION
## Summary
- group trigger discovery by gallery attribute so only matching links populate the viewer
- expose a configurable gallery group attribute in the plugin settings and frontend defaults
- extend the Playwright E2E suite with a two-gallery scenario to ensure navigation stays scoped

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc224ed0b8832ead3406ef979d31c4