### PR TITLE
Respect reduced motion preference for slideshow autoplay

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -31,6 +31,8 @@
         const SCROLL_LOCK_CLASS = 'mga-scroll-locked';
         let mainSwiper = null;
         let thumbsSwiper = null;
+        let cleanupAutoplayPreferenceListener = null;
+        let autoplayWasRunningBeforePreferenceChange = false;
         const preloadedUrls = new Set();
         let resizeTimeout;
         let isResizeListenerAttached = false;
@@ -1142,6 +1144,12 @@
         }
 
         function initSwiper(viewer, images) {
+            if (typeof cleanupAutoplayPreferenceListener === 'function') {
+                cleanupAutoplayPreferenceListener();
+                cleanupAutoplayPreferenceListener = null;
+            }
+            autoplayWasRunningBeforePreferenceChange = false;
+
             const mainSwiperContainer = viewer.querySelector('.mga-main-swiper');
             const thumbsSwiperContainer = viewer.querySelector('.mga-thumbs-swiper');
 
@@ -1164,16 +1172,23 @@
 
             // L'instance principale peut activer `loop` en fonction des réglages.
             // On passe par le wrapper pour atténuer l'avertissement Swiper localement.
+            const autoplayConfig = {
+                delay: parseInt(settings.delay, 10) * 1000 || 4000,
+                disableOnInteraction: false,
+                pauseOnMouseEnter: false,
+            };
+
+            const prefersReducedMotionQuery = (typeof window !== 'undefined' && typeof window.matchMedia === 'function')
+                ? window.matchMedia('(prefers-reduced-motion: reduce)')
+                : null;
+
+            const prefersReducedMotion = !!(prefersReducedMotionQuery && prefersReducedMotionQuery.matches);
+
             const mainSwiperConfig = {
                 zoom: true,
                 spaceBetween: 10,
                 loop: !!settings.loop,
                 navigation: { nextEl: '.swiper-button-next', prevEl: '.swiper-button-prev' },
-                autoplay: {
-                    delay: parseInt(settings.delay, 10) * 1000 || 4000,
-                    disableOnInteraction: false,
-                    pauseOnMouseEnter: false,
-                },
                 on: {
                     init: function(swiper) {
                         preloadNeighboringImages(images, swiper.realIndex);
@@ -1212,6 +1227,10 @@
                 },
             };
 
+            if (!prefersReducedMotion) {
+                mainSwiperConfig.autoplay = Object.assign({}, autoplayConfig);
+            }
+
             if (thumbsSwiper) {
                 mainSwiperConfig.thumbs = { swiper: thumbsSwiper };
             }
@@ -1228,12 +1247,85 @@
                 return;
             }
 
-            if (!mainSwiper.autoplay) {
-                debug.log(mga__( 'L’extension autoplay de Swiper est indisponible.', 'lightbox-jlg' ), true);
-            } else if (settings.autoplay_start) {
-                mainSwiper.autoplay.start();
+            const autoplayInstance = mainSwiper.autoplay;
+            const hasAutoplayModule = !!(autoplayInstance && typeof autoplayInstance.start === 'function' && typeof autoplayInstance.stop === 'function');
+
+            const applyAutoplayParams = () => {
+                if (!mainSwiper || mainSwiper.destroyed) {
+                    return;
+                }
+
+                if (mainSwiper.params && typeof mainSwiper.params === 'object') {
+                    const paramsAutoplay = mainSwiper.params.autoplay && typeof mainSwiper.params.autoplay === 'object'
+                        ? mainSwiper.params.autoplay
+                        : (mainSwiper.params.autoplay = {});
+                    Object.assign(paramsAutoplay, autoplayConfig);
+                }
+
+                if (mainSwiper.originalParams && typeof mainSwiper.originalParams === 'object') {
+                    const originalAutoplay = mainSwiper.originalParams.autoplay && typeof mainSwiper.originalParams.autoplay === 'object'
+                        ? mainSwiper.originalParams.autoplay
+                        : (mainSwiper.originalParams.autoplay = {});
+                    Object.assign(originalAutoplay, autoplayConfig);
+                }
+            };
+
+            if (!hasAutoplayModule) {
+                if (!prefersReducedMotion) {
+                    debug.log(mga__( 'L’extension autoplay de Swiper est indisponible.', 'lightbox-jlg' ), true);
+                }
             } else {
-                 mainSwiper.autoplay.stop();
+                if (!prefersReducedMotion) {
+                    applyAutoplayParams();
+                    if (settings.autoplay_start) {
+                        autoplayInstance.start();
+                    } else {
+                        autoplayInstance.stop();
+                    }
+                } else {
+                    autoplayInstance.stop();
+                }
+
+                if (prefersReducedMotionQuery) {
+                    const handleReducedMotionChange = (event) => {
+                        if (!mainSwiper || mainSwiper.destroyed) {
+                            return;
+                        }
+
+                        const instance = mainSwiper.autoplay;
+                        if (!instance || typeof instance.start !== 'function' || typeof instance.stop !== 'function') {
+                            return;
+                        }
+
+                        const matchesReducedMotion = !!event.matches;
+
+                        if (matchesReducedMotion) {
+                            autoplayWasRunningBeforePreferenceChange = Boolean(instance.running);
+                            instance.stop();
+                        } else {
+                            const shouldResume = autoplayWasRunningBeforePreferenceChange || !!settings.autoplay_start;
+                            autoplayWasRunningBeforePreferenceChange = false;
+                            applyAutoplayParams();
+                            if (shouldResume) {
+                                instance.start();
+                            } else if (instance.running) {
+                                instance.stop();
+                            }
+                        }
+                    };
+
+                    if (typeof prefersReducedMotionQuery.addEventListener === 'function') {
+                        prefersReducedMotionQuery.addEventListener('change', handleReducedMotionChange);
+                        cleanupAutoplayPreferenceListener = () => {
+                            prefersReducedMotionQuery.removeEventListener('change', handleReducedMotionChange);
+                        };
+                    } else if (typeof prefersReducedMotionQuery.addListener === 'function') {
+                        prefersReducedMotionQuery.addListener(handleReducedMotionChange);
+                        cleanupAutoplayPreferenceListener = () => {
+                            prefersReducedMotionQuery.removeListener(handleReducedMotionChange);
+                        };
+                    }
+                }
             }
         }
         
@@ -1347,6 +1439,11 @@
             if(mainSwiper && mainSwiper.autoplay) {
                 mainSwiper.autoplay.stop();
             }
+            if (typeof cleanupAutoplayPreferenceListener === 'function') {
+                cleanupAutoplayPreferenceListener();
+                cleanupAutoplayPreferenceListener = null;
+            }
+            autoplayWasRunningBeforePreferenceChange = false;
             window.removeEventListener('resize', handleResize);
             isResizeListenerAttached = false;
             if (viewerFocusTrapHandler) {

--- a/tests/e2e/gallery-viewer.spec.ts
+++ b/tests/e2e/gallery-viewer.spec.ts
@@ -314,4 +314,138 @@ test.describe('Gallery viewer', () => {
             await cleanup();
         }
     });
+
+    test('respects reduced motion preference for autoplay', async ({ page, requestUtils }) => {
+        await page.addInitScript(() => {
+            const mediaQuery = '(prefers-reduced-motion: reduce)';
+            const listeners = new Set<((event: { matches: boolean; media: string; type: string }) => void)>();
+            const mql = {
+                matches: true,
+                media: mediaQuery,
+                onchange: null as ((event: { matches: boolean; media: string; type: string }) => void) | null,
+                addEventListener: (event: string, handler: (payload: { matches: boolean; media: string; type: string }) => void) => {
+                    if (event === 'change') {
+                        listeners.add(handler);
+                    }
+                },
+                removeEventListener: (event: string, handler: (payload: { matches: boolean; media: string; type: string }) => void) => {
+                    if (event === 'change') {
+                        listeners.delete(handler);
+                    }
+                },
+                addListener: (handler: (payload: { matches: boolean; media: string; type: string }) => void) => {
+                    listeners.add(handler);
+                },
+                removeListener: (handler: (payload: { matches: boolean; media: string; type: string }) => void) => {
+                    listeners.delete(handler);
+                },
+                dispatchEvent: (event: { matches: boolean; media: string; type: string }) => {
+                    if (!event || event.type !== 'change') {
+                        return false;
+                    }
+                    listeners.forEach((handler) => handler(event));
+                    return true;
+                },
+            };
+
+            const notifyListeners = (matches: boolean) => {
+                if (mql.matches === matches) {
+                    return;
+                }
+                mql.matches = matches;
+                const event = { matches, media: mediaQuery, type: 'change' };
+                if (typeof mql.onchange === 'function') {
+                    mql.onchange(event);
+                }
+                listeners.forEach((handler) => {
+                    handler(event);
+                });
+            };
+
+            Object.defineProperty(window, '__setReducedMotionPreference', {
+                value: notifyListeners,
+                configurable: true,
+            });
+
+            const originalMatchMedia = window.matchMedia ? window.matchMedia.bind(window) : undefined;
+            window.matchMedia = (query: string) => {
+                if (query === mediaQuery) {
+                    return mql;
+                }
+                if (originalMatchMedia) {
+                    return originalMatchMedia(query);
+                }
+                return {
+                    matches: false,
+                    media: query,
+                    onchange: null,
+                    addListener() {},
+                    removeListener() {},
+                    addEventListener() {},
+                    removeEventListener() {},
+                    dispatchEvent() {
+                        return false;
+                    },
+                };
+            };
+        });
+
+        const { post, uploads, cleanup } = await createPublishedGalleryPost(requestUtils, 'Gallery viewer reduced motion');
+
+        try {
+            await page.goto(post.link);
+
+            await page.evaluate(() => {
+                const settings = (window as typeof window & { mga_settings?: Record<string, unknown> }).mga_settings || {};
+                settings.autoplay_start = true;
+                (window as typeof window & { mga_settings?: Record<string, unknown> }).mga_settings = settings;
+            });
+
+            const trigger = page.locator(`a[href="${uploads[0].source_url}"]`);
+            await expect(trigger.locator('img')).toBeVisible();
+            await trigger.click();
+
+            const viewer = page.locator('#mga-viewer');
+            await expect(viewer).toBeVisible();
+
+            await page.waitForFunction(() => {
+                const swiperEl = document.querySelector('.mga-main-swiper');
+                return Boolean(swiperEl && (swiperEl as any).swiper && (swiperEl as any).swiper.autoplay);
+            });
+
+            const initialRunning = await page.evaluate(() => {
+                const swiperEl = document.querySelector('.mga-main-swiper') as any;
+                return Boolean(swiperEl?.swiper?.autoplay?.running);
+            });
+            expect(initialRunning).toBe(false);
+
+            await page.evaluate(() => {
+                const setter = (window as typeof window & { __setReducedMotionPreference?: (value: boolean) => void }).__setReducedMotionPreference;
+                setter?.(false);
+            });
+
+            await page.waitForFunction(() => {
+                const swiperEl = document.querySelector('.mga-main-swiper') as any;
+                return Boolean(swiperEl?.swiper?.autoplay?.running);
+            });
+
+            await page.evaluate(() => {
+                const setter = (window as typeof window & { __setReducedMotionPreference?: (value: boolean) => void }).__setReducedMotionPreference;
+                setter?.(true);
+            });
+
+            await page.waitForFunction(() => {
+                const swiperEl = document.querySelector('.mga-main-swiper') as any;
+                return Boolean(swiperEl?.swiper?.autoplay && !swiperEl.swiper.autoplay.running);
+            });
+
+            const finalRunning = await page.evaluate(() => {
+                const swiperEl = document.querySelector('.mga-main-swiper') as any;
+                return Boolean(swiperEl?.swiper?.autoplay?.running);
+            });
+            expect(finalRunning).toBe(false);
+        } finally {
+            await cleanup();
+        }
+    });
 });


### PR DESCRIPTION
## Summary
- gate the Swiper autoplay configuration behind the prefers-reduced-motion media query and reuse the config when autoplay can run
- react to prefers-reduced-motion changes by starting or stopping autoplay and cleaning up listeners when the viewer closes
- add a Playwright scenario that simulates matchMedia to ensure autoplay stays paused while reduced motion is enabled

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc2248f86c832e968d6d2c4a4b386e