### PR TITLE
Fix neighbor preloading compatibility

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -1398,7 +1398,8 @@
             const prevIndex = (currentIndex - 1 + images.length) % images.length;
             
             [nextIndex, prevIndex].forEach(index => {
-                const imageUrl = images[index]?.highResUrl;
+                const neighbor = images[index];
+                const imageUrl = neighbor && neighbor.highResUrl;
                 if (imageUrl && !preloadedUrls.has(imageUrl)) {
                     debug.log(mgaSprintf(mga__( "Préchargement de l'image %s", 'lightbox-jlg' ), index));
                     const img = new Image();

--- a/tests/js/gallery-slideshow.test.js
+++ b/tests/js/gallery-slideshow.test.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadPreloadNeighboringImagesFactory() {
+    const filePath = path.resolve(__dirname, '../../ma-galerie-automatique/assets/js/gallery-slideshow.js');
+    const scriptContent = fs.readFileSync(filePath, 'utf8');
+    const match = scriptContent.match(/function preloadNeighboringImages\(images, currentIndex\) {([\s\S]*?)\n        }/);
+
+    if (!match) {
+        throw new Error('Unable to locate preloadNeighboringImages in gallery-slideshow.js');
+    }
+
+    const functionSource = `function preloadNeighboringImages(images, currentIndex) {${match[1]}\n        }`;
+
+    return new Function('preloadedUrls', 'debug', 'mgaSprintf', 'mga__', 'Image', `\n        ${functionSource}\n        return preloadNeighboringImages;\n    `);
+}
+
+describe('preloadNeighboringImages', () => {
+    it('skips preloading when a neighboring image is undefined', () => {
+        const createPreloader = loadPreloadNeighboringImagesFactory();
+        const preloadedUrls = new Set();
+        const debug = { log: jest.fn() };
+        const mgaSprintf = (format, value) => format.replace('%s', String(value));
+        const mga__ = (text) => text;
+        const imageInstances = [];
+
+        function ImageMock() {
+            imageInstances.push(this);
+        }
+
+        const preloadNeighboringImages = createPreloader(preloadedUrls, debug, mgaSprintf, mga__, ImageMock);
+        const images = [
+            { highResUrl: 'https://example.com/image-1.jpg' },
+            undefined,
+            { highResUrl: 'https://example.com/image-3.jpg' },
+        ];
+
+        expect(() => preloadNeighboringImages(images, 0)).not.toThrow();
+
+        expect(preloadedUrls.has('https://example.com/image-3.jpg')).toBe(true);
+        expect(preloadedUrls.has(undefined)).toBe(false);
+        expect(imageInstances).toHaveLength(1);
+        expect(imageInstances[0].src).toBe('https://example.com/image-3.jpg');
+        expect(debug.log).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
## Summary
- replace optional chaining in the slideshow preloader with compatibility-safe access
- add a Jest test to ensure undefined neighboring images do not break preloading

## Testing
- npm run test:js

------
https://chatgpt.com/codex/tasks/task_e_68dc452ccd10832eb321f630868eaa63