### PR TITLE
Adjust fallback group resolution for gallery slideshow

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -810,6 +810,10 @@
 
             attributeCandidates.push('data-mga-gallery', 'rel');
 
+            const normalizedConfiguredGroupAttribute = configuredGroupAttribute
+                ? configuredGroupAttribute.toLowerCase()
+                : '';
+
             for (const attrName of attributeCandidates) {
                 if (!attrName) {
                     continue;
@@ -824,7 +828,7 @@
                 }
             }
 
-            if (configuredGroupAttribute) {
+            if (normalizedConfiguredGroupAttribute === 'href') {
                 const hrefValue = link.getAttribute('href');
                 if (typeof hrefValue === 'string') {
                     const trimmedHref = hrefValue.trim();


### PR DESCRIPTION
## Summary
- ensure gallery fallback grouping uses the default group identifier when no group attributes are present
- keep href-based grouping available when explicitly selected in the settings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc4a587f48832eb202accef35ce95a