### PR TITLE
Handle cached echo background images

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -14,6 +14,40 @@
             });
         };
 
+    function updateEchoBackground(viewer, imageUrl) {
+        if (!viewer) {
+            return;
+        }
+
+        const bgContainer = viewer.querySelector('.mga-echo-bg');
+        if (!bgContainer) return;
+
+        const newImg = document.createElement('img');
+        newImg.className = 'mga-echo-bg__image';
+        let hasLoaded = false;
+
+        const handleLoad = () => {
+            if (hasLoaded) {
+                return;
+            }
+            hasLoaded = true;
+            const oldImg = bgContainer.querySelector('.mga-visible');
+            if (oldImg) {
+                oldImg.classList.remove('mga-visible');
+                setTimeout(() => { if(oldImg.parentElement) oldImg.parentElement.removeChild(oldImg); }, 400);
+            }
+            bgContainer.appendChild(newImg);
+            setTimeout(() => newImg.classList.add('mga-visible'), 10);
+        };
+
+        newImg.onload = handleLoad;
+        newImg.src = imageUrl;
+
+        if (newImg.complete) {
+            setTimeout(() => handleLoad());
+        }
+    }
+
     function initGalleryViewer() {
         const settings = window.mga_settings || {};
         const IMAGE_FILE_PATTERN = /\.(jpe?g|png|gif|bmp|webp|avif|svg)(?:\?.*)?(?:#.*)?$/i;
@@ -1408,23 +1442,6 @@
             });
         }
 
-        function updateEchoBackground(viewer, imageUrl) {
-            const bgContainer = viewer.querySelector('.mga-echo-bg');
-            if (!bgContainer) return;
-            const newImg = document.createElement('img');
-            newImg.className = 'mga-echo-bg__image';
-            newImg.src = imageUrl;
-            newImg.onload = () => {
-                const oldImg = bgContainer.querySelector('.mga-visible');
-                if (oldImg) {
-                    oldImg.classList.remove('mga-visible');
-                    setTimeout(() => { if(oldImg.parentElement) oldImg.parentElement.removeChild(oldImg); }, 400);
-                }
-                bgContainer.appendChild(newImg);
-                setTimeout(() => newImg.classList.add('mga-visible'), 10);
-            };
-        }
-
         function updateInfo(viewer, images, index) {
             if (images[index]) {
                 viewer.querySelector('#mga-caption').textContent = images[index].caption;
@@ -1559,5 +1576,9 @@
         document.addEventListener('DOMContentLoaded', initGalleryViewer);
     } else {
         initGalleryViewer();
+    }
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports.updateEchoBackground = updateEchoBackground;
     }
 })();

--- a/tests/js/gallery-slideshow.test.js
+++ b/tests/js/gallery-slideshow.test.js
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+
+describe('updateEchoBackground', () => {
+    let updateEchoBackground;
+    const originalCreateElement = document.createElement.bind(document);
+
+    beforeEach(() => {
+        jest.resetModules();
+        jest.useFakeTimers();
+        document.body.innerHTML = '';
+
+        Object.defineProperty(document, 'readyState', {
+            value: 'complete',
+            configurable: true,
+        });
+
+        global.Swiper = function() {};
+
+        ({ updateEchoBackground } = require('../../ma-galerie-automatique/assets/js/gallery-slideshow'));
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+        delete global.Swiper;
+        delete document.readyState;
+    });
+
+    it('applies the mga-visible class when the image is already cached', () => {
+        const viewer = document.createElement('div');
+        const bgContainer = document.createElement('div');
+        bgContainer.className = 'mga-echo-bg';
+        const oldImg = document.createElement('img');
+        oldImg.className = 'mga-echo-bg__image mga-visible';
+        bgContainer.appendChild(oldImg);
+        viewer.appendChild(bgContainer);
+        document.body.appendChild(viewer);
+
+        jest.spyOn(document, 'createElement').mockImplementation((tagName, ...args) => {
+            const element = originalCreateElement(tagName, ...args);
+            if (tagName.toLowerCase() === 'img') {
+                Object.defineProperty(element, 'complete', {
+                    configurable: true,
+                    value: true,
+                });
+            }
+            return element;
+        });
+
+        updateEchoBackground(viewer, 'https://example.com/image.jpg');
+
+        jest.advanceTimersByTime(10);
+
+        const images = bgContainer.querySelectorAll('img');
+        expect(images.length).toBe(2);
+        const newImg = images[1];
+        expect(newImg.classList.contains('mga-visible')).toBe(true);
+        expect(oldImg.classList.contains('mga-visible')).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- ensure the echo background loader registers its handler before setting the source and manually fires it for cached images
- expose the loader for testing and cover the cached-image scenario with a new Jest test

## Testing
- npm run test:js

------
https://chatgpt.com/codex/tasks/task_e_68dc439f5104832eaac79c0523ff0ad6