### PR TITLE
Refactor gallery helpers into shared module

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -1,3 +1,5 @@
+const galleryHelpers = require('./utils/gallery-helpers');
+
 (function() {
     "use strict";
 
@@ -269,120 +271,6 @@
             return result;
         }
 
-        function isExplicitFallbackAllowed(linkElement) {
-            if (!linkElement) return false;
-            if (linkElement.hasAttribute('data-mga-allow-fallback')) return true;
-            if (linkElement.dataset) {
-                const allowFlag = linkElement.dataset.mgaAllowFallback;
-                if (typeof allowFlag !== 'undefined' && allowFlag !== '0' && allowFlag !== 'false') {
-                    return true;
-                }
-                if (linkElement.dataset.mgaHighres) {
-                    return true;
-                }
-                const linkType = linkElement.dataset.type || linkElement.dataset.wpType;
-                if (typeof linkType === 'string' && linkType.toLowerCase() === 'attachment') {
-                    return true;
-                }
-            }
-            const rel = linkElement.getAttribute('rel');
-            if (rel && rel.split(/\s+/).includes('mga-allow-fallback')) {
-                return true;
-            }
-            const dataType = linkElement.getAttribute('data-type');
-            if (typeof dataType === 'string' && dataType.toLowerCase() === 'attachment') {
-                return true;
-            }
-            const href = linkElement.getAttribute('href');
-            if (typeof href === 'string') {
-                if (/[?&]attachment_id=\d+/i.test(href)) {
-                    return true;
-                }
-                if (/\/attachment\//i.test(href)) {
-                    return true;
-                }
-                try {
-                    const baseHref = (typeof window !== 'undefined' && window.location)
-                        ? window.location.href
-                        : undefined;
-                    const url = new URL(href, baseHref);
-                    if (url.searchParams && url.searchParams.has('attachment_id')) {
-                        return true;
-                    }
-                } catch (error) {
-                    // Ignored : l'URL relative sera déjà couverte par les expressions régulières ci-dessus.
-                }
-            }
-            return false;
-        }
-
-        function getImageDataAttributes(innerImg, options = {}) {
-            if (!innerImg) return null;
-
-            const { excludeLarge = false } = options;
-
-            const attributePriority = [
-                'data-mga-highres',
-                'data-full-url',
-                'data-large-file',
-                'data-orig-file',
-                'data-src',
-                'data-lazy-src'
-            ];
-            const datasetToAttributesMap = {
-                mgaHighres: 'data-mga-highres',
-                fullUrl: 'data-full-url',
-                largeFile: 'data-large-file',
-                origFile: 'data-orig-file',
-                src: 'data-src',
-                lazySrc: 'data-lazy-src'
-            };
-            const collected = [];
-
-            for (const attr of attributePriority) {
-                const value = innerImg.getAttribute(attr);
-                if (value) {
-                    collected.push({ key: attr, value: value.trim() });
-                }
-            }
-
-            if (innerImg.dataset) {
-                for (const [datasetKey, attributeName] of Object.entries(datasetToAttributesMap)) {
-                    const datasetValue = innerImg.dataset[datasetKey];
-                    if (datasetValue && !collected.some(item => item.key === attributeName)) {
-                        collected.push({ key: attributeName, value: datasetValue.trim() });
-                    }
-                }
-            }
-
-            if (!collected.length) {
-                return null;
-            }
-
-            if (excludeLarge) {
-                const largeKeys = new Set(['data-full-url', 'data-large-file', 'data-orig-file']);
-                const lightweightPreference = ['data-src', 'data-lazy-src', 'data-mga-highres'];
-                const hasLightweightAlternative = collected.some(item => !largeKeys.has(item.key));
-
-                if (hasLightweightAlternative) {
-                    for (const preferredKey of lightweightPreference) {
-                        const candidate = collected.find(item => item.key === preferredKey && item.value);
-                        if (candidate) {
-                            return candidate.value;
-                        }
-                    }
-
-                    const fallbackCandidate = collected.find(item => !largeKeys.has(item.key) && item.value);
-                    if (fallbackCandidate) {
-                        return fallbackCandidate.value;
-                    }
-                }
-            }
-
-            const firstEntry = collected.find(item => item.value);
-            return firstEntry ? firstEntry.value : null;
-        }
-
         function sanitizeThumbnailUrl(candidate) {
             if (typeof candidate !== 'string') {
                 return '';
@@ -399,37 +287,6 @@
 
             if (/^(?:data:|blob:)/i.test(trimmed)) {
                 return '';
-            }
-
-            return trimmed;
-        }
-
-        function sanitizeHighResUrl(candidate) {
-            if (typeof candidate !== 'string') {
-                return '';
-            }
-
-            const trimmed = candidate.trim();
-            if (!trimmed) {
-                return '';
-            }
-
-            if (/^\/\//.test(trimmed)) {
-                const location = typeof window !== 'undefined' ? window.location : null;
-                const protocol = location && typeof location.protocol === 'string'
-                    ? location.protocol.toLowerCase()
-                    : '';
-                if (protocol === 'http:' || protocol === 'https:') {
-                    return `${protocol}${trimmed}`;
-                }
-                return `https:${trimmed}`;
-            }
-
-            if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(trimmed)) {
-                if (!/^https?:/i.test(trimmed)) {
-                    return '';
-                }
-                return trimmed;
             }
 
             return trimmed;
@@ -454,91 +311,6 @@
 
             const dataAttributeUrl = getImageDataAttributes(innerImg, { excludeLarge: true });
             return sanitizeThumbnailUrl(dataAttributeUrl);
-        }
-
-        function parseSrcset(innerImg) {
-            if (!innerImg || !innerImg.srcset) {
-                return null;
-            }
-
-            const entries = innerImg.srcset
-                .split(',')
-                .map(entry => entry.trim())
-                .filter(entry => entry.length > 0)
-                .map(entry => {
-                    const parts = entry.split(/\s+/);
-                    const candidateUrl = parts[0];
-                    let score = 0;
-                    if (parts[1]) {
-                        const descriptor = parts[1].trim();
-                        if (/^[0-9]+w$/i.test(descriptor)) {
-                            score = parseInt(descriptor, 10);
-                        } else if (/^[0-9]*\.?[0-9]+x$/i.test(descriptor)) {
-                            score = parseFloat(descriptor) * 1000;
-                        }
-                    }
-                    return { url: candidateUrl, score };
-                })
-                .filter(candidate => candidate.url);
-
-            if (!entries.length) {
-                return null;
-            }
-
-            entries.sort((a, b) => b.score - a.score);
-            return entries[0].url;
-        }
-
-        function getHighResUrl(linkElement) {
-            if (!linkElement) return null;
-
-            const href = linkElement.getAttribute('href') || '';
-            const isMediaHref = IMAGE_FILE_PATTERN.test(href);
-            const fallbackAllowed = isMediaHref || isExplicitFallbackAllowed(linkElement);
-            const sanitizedHref = isMediaHref ? sanitizeHighResUrl(href) : null;
-
-            if (fallbackAllowed && linkElement.dataset && linkElement.dataset.mgaHighres) {
-                const sanitizedDatasetUrl = sanitizeHighResUrl(linkElement.dataset.mgaHighres);
-                if (sanitizedDatasetUrl) {
-                    return sanitizedDatasetUrl;
-                }
-            }
-
-            const innerImg = linkElement.querySelector('img');
-            if (!innerImg) return null;
-
-            if (fallbackAllowed) {
-                const dataAttrUrl = getImageDataAttributes(innerImg);
-                const sanitizedDataAttrUrl = sanitizeHighResUrl(dataAttrUrl);
-                if (sanitizedDataAttrUrl) {
-                    return sanitizedDataAttrUrl;
-                }
-            }
-
-            if (!fallbackAllowed) {
-                return null;
-            }
-
-            const srcsetUrl = sanitizeHighResUrl(parseSrcset(innerImg));
-            if (srcsetUrl) {
-                return srcsetUrl;
-            }
-
-            if (sanitizedHref) {
-                return sanitizedHref;
-            }
-
-            const currentSrc = sanitizeHighResUrl(innerImg.currentSrc);
-            if (currentSrc) {
-                return currentSrc;
-            }
-
-            const fallbackSrc = sanitizeHighResUrl(innerImg.src);
-            if (fallbackSrc) {
-                return fallbackSrc;
-            }
-
-            return null;
         }
 
         function getViewer() {
@@ -797,45 +569,14 @@
             ? settings.groupAttribute.trim()
             : '';
 
-        const resolveLinkGroupId = (link) => {
-            if (!(link instanceof Element)) {
-                return FALLBACK_GROUP_ID;
-            }
-
-            const attributeCandidates = [];
-
-            if (configuredGroupAttribute) {
-                attributeCandidates.push(configuredGroupAttribute);
-            }
-
-            attributeCandidates.push('data-mga-gallery', 'rel');
-
-            for (const attrName of attributeCandidates) {
-                if (!attrName) {
-                    continue;
-                }
-
-                const rawValue = link.getAttribute(attrName);
-                if (typeof rawValue === 'string') {
-                    const trimmed = rawValue.trim();
-                    if (trimmed) {
-                        return `${attrName}:${trimmed}`;
-                    }
-                }
-            }
-
-            if (configuredGroupAttribute) {
-                const hrefValue = link.getAttribute('href');
-                if (typeof hrefValue === 'string') {
-                    const trimmedHref = hrefValue.trim();
-                    if (trimmedHref) {
-                        return `href:${trimmedHref}`;
-                    }
-                }
-            }
-
-            return FALLBACK_GROUP_ID;
-        };
+        const resolveLinkGroupId = (link) => galleryHelpers.resolveLinkGroupId(link, {
+            fallbackGroupId: FALLBACK_GROUP_ID,
+            configuredGroupAttribute,
+        });
+        const getHighResUrl = (linkElement) => galleryHelpers.getHighResUrl(linkElement, {
+            imageFilePattern: IMAGE_FILE_PATTERN,
+        });
+        const getImageDataAttributes = galleryHelpers.getImageDataAttributes;
 
         const getTriggerLinks = (shouldUpdateDebug = true) => {
             const links = Array.from(contentArea.querySelectorAll('a')).filter(a => a.querySelector('img'));

--- a/ma-galerie-automatique/assets/js/utils/gallery-helpers.js
+++ b/ma-galerie-automatique/assets/js/utils/gallery-helpers.js
@@ -1,0 +1,295 @@
+'use strict';
+
+const DEFAULT_FALLBACK_GROUP_ID = '__mga-default-group__';
+const DEFAULT_IMAGE_FILE_PATTERN = /\.(jpe?g|png|gif|bmp|webp|avif|svg)(?:\?.*)?(?:#.*)?$/i;
+
+function resolveLinkGroupId(link, options = {}) {
+    const {
+        fallbackGroupId = DEFAULT_FALLBACK_GROUP_ID,
+        configuredGroupAttribute = '',
+    } = options;
+
+    if (!(link instanceof Element)) {
+        return fallbackGroupId;
+    }
+
+    const attributeCandidates = [];
+    const trimmedConfiguredAttribute = typeof configuredGroupAttribute === 'string'
+        ? configuredGroupAttribute.trim()
+        : '';
+
+    if (trimmedConfiguredAttribute) {
+        attributeCandidates.push(trimmedConfiguredAttribute);
+    }
+
+    attributeCandidates.push('data-mga-gallery', 'rel');
+
+    for (const attrName of attributeCandidates) {
+        if (!attrName) {
+            continue;
+        }
+
+        const rawValue = link.getAttribute(attrName);
+        if (typeof rawValue === 'string') {
+            const trimmed = rawValue.trim();
+            if (trimmed) {
+                return `${attrName}:${trimmed}`;
+            }
+        }
+    }
+
+    if (trimmedConfiguredAttribute) {
+        const hrefValue = link.getAttribute('href');
+        if (typeof hrefValue === 'string') {
+            const trimmedHref = hrefValue.trim();
+            if (trimmedHref) {
+                return `href:${trimmedHref}`;
+            }
+        }
+    }
+
+    return fallbackGroupId;
+}
+
+function isExplicitFallbackAllowed(linkElement) {
+    if (!linkElement) return false;
+    if (linkElement.hasAttribute('data-mga-allow-fallback')) return true;
+    if (linkElement.dataset) {
+        const allowFlag = linkElement.dataset.mgaAllowFallback;
+        if (typeof allowFlag !== 'undefined' && allowFlag !== '0' && allowFlag !== 'false') {
+            return true;
+        }
+        if (linkElement.dataset.mgaHighres) {
+            return true;
+        }
+        const linkType = linkElement.dataset.type || linkElement.dataset.wpType;
+        if (typeof linkType === 'string' && linkType.toLowerCase() === 'attachment') {
+            return true;
+        }
+    }
+    const rel = linkElement.getAttribute('rel');
+    if (rel && rel.split(/\s+/).includes('mga-allow-fallback')) {
+        return true;
+    }
+    const dataType = linkElement.getAttribute('data-type');
+    if (typeof dataType === 'string' && dataType.toLowerCase() === 'attachment') {
+        return true;
+    }
+    const href = linkElement.getAttribute('href');
+    if (typeof href === 'string') {
+        if (/[?&]attachment_id=\d+/i.test(href)) {
+            return true;
+        }
+        if (/\/attachment\//i.test(href)) {
+            return true;
+        }
+        try {
+            const baseHref = (typeof window !== 'undefined' && window.location)
+                ? window.location.href
+                : undefined;
+            const url = new URL(href, baseHref);
+            if (url.searchParams && url.searchParams.has('attachment_id')) {
+                return true;
+            }
+        } catch (error) {
+            // Relative URLs already handled above.
+        }
+    }
+    return false;
+}
+
+function sanitizeHighResUrl(candidate) {
+    if (typeof candidate !== 'string') {
+        return '';
+    }
+
+    const trimmed = candidate.trim();
+    if (!trimmed) {
+        return '';
+    }
+
+    if (/^\/\//.test(trimmed)) {
+        const location = typeof window !== 'undefined' ? window.location : null;
+        const protocol = location && typeof location.protocol === 'string'
+            ? location.protocol.toLowerCase()
+            : '';
+        if (protocol === 'http:' || protocol === 'https:') {
+            return `${protocol}${trimmed}`;
+        }
+        return `https:${trimmed}`;
+    }
+
+    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(trimmed)) {
+        if (!/^https?:/i.test(trimmed)) {
+            return '';
+        }
+        return trimmed;
+    }
+
+    return trimmed;
+}
+
+function getImageDataAttributes(innerImg, options = {}) {
+    if (!innerImg) return null;
+
+    const { excludeLarge = false } = options;
+
+    const attributePriority = [
+        'data-mga-highres',
+        'data-full-url',
+        'data-large-file',
+        'data-orig-file',
+        'data-src',
+        'data-lazy-src'
+    ];
+    const datasetToAttributesMap = {
+        mgaHighres: 'data-mga-highres',
+        fullUrl: 'data-full-url',
+        largeFile: 'data-large-file',
+        origFile: 'data-orig-file',
+        src: 'data-src',
+        lazySrc: 'data-lazy-src'
+    };
+    const collected = [];
+
+    for (const attr of attributePriority) {
+        const value = innerImg.getAttribute(attr);
+        if (value) {
+            collected.push({ key: attr, value: value.trim() });
+        }
+    }
+
+    if (innerImg.dataset) {
+        for (const [datasetKey, attributeName] of Object.entries(datasetToAttributesMap)) {
+            const datasetValue = innerImg.dataset[datasetKey];
+            if (datasetValue && !collected.some(item => item.key === attributeName)) {
+                collected.push({ key: attributeName, value: datasetValue.trim() });
+            }
+        }
+    }
+
+    if (!collected.length) {
+        return null;
+    }
+
+    if (excludeLarge) {
+        const largeKeys = new Set(['data-full-url', 'data-large-file', 'data-orig-file']);
+        const lightweightPreference = ['data-src', 'data-lazy-src', 'data-mga-highres'];
+        const hasLightweightAlternative = collected.some(item => !largeKeys.has(item.key));
+
+        if (hasLightweightAlternative) {
+            for (const preferredKey of lightweightPreference) {
+                const candidate = collected.find(item => item.key === preferredKey && item.value);
+                if (candidate) {
+                    return candidate.value;
+                }
+            }
+
+            const fallbackCandidate = collected.find(item => !largeKeys.has(item.key) && item.value);
+            if (fallbackCandidate) {
+                return fallbackCandidate.value;
+            }
+        }
+    }
+
+    const firstEntry = collected.find(item => item.value);
+    return firstEntry ? firstEntry.value : null;
+}
+
+function parseSrcset(innerImg) {
+    if (!innerImg || !innerImg.srcset) {
+        return null;
+    }
+
+    const entries = innerImg.srcset
+        .split(',')
+        .map(entry => entry.trim())
+        .filter(entry => entry.length > 0)
+        .map(entry => {
+            const parts = entry.split(/\s+/);
+            const candidateUrl = parts[0];
+            let score = 0;
+            if (parts[1]) {
+                const descriptor = parts[1].trim();
+                if (/^[0-9]+w$/i.test(descriptor)) {
+                    score = parseInt(descriptor, 10);
+                } else if (/^[0-9]*\.?[0-9]+x$/i.test(descriptor)) {
+                    score = parseFloat(descriptor) * 1000;
+                }
+            }
+            return { url: candidateUrl, score };
+        })
+        .filter(candidate => candidate.url);
+
+    if (!entries.length) {
+        return null;
+    }
+
+    entries.sort((a, b) => b.score - a.score);
+    return entries[0].url;
+}
+
+function getHighResUrl(linkElement, options = {}) {
+    if (!linkElement) return null;
+
+    const {
+        imageFilePattern = DEFAULT_IMAGE_FILE_PATTERN,
+    } = options;
+
+    const href = linkElement.getAttribute('href') || '';
+    const isMediaHref = imageFilePattern.test(href);
+    const fallbackAllowed = isMediaHref || isExplicitFallbackAllowed(linkElement);
+    const sanitizedHref = isMediaHref ? sanitizeHighResUrl(href) : null;
+
+    if (fallbackAllowed && linkElement.dataset && linkElement.dataset.mgaHighres) {
+        const sanitizedDatasetUrl = sanitizeHighResUrl(linkElement.dataset.mgaHighres);
+        if (sanitizedDatasetUrl) {
+            return sanitizedDatasetUrl;
+        }
+    }
+
+    const innerImg = linkElement.querySelector('img');
+    if (!innerImg) return null;
+
+    if (fallbackAllowed) {
+        const dataAttrUrl = getImageDataAttributes(innerImg);
+        const sanitizedDataAttrUrl = sanitizeHighResUrl(dataAttrUrl);
+        if (sanitizedDataAttrUrl) {
+            return sanitizedDataAttrUrl;
+        }
+    }
+
+    if (!fallbackAllowed) {
+        return null;
+    }
+
+    const srcsetUrl = sanitizeHighResUrl(parseSrcset(innerImg));
+    if (srcsetUrl) {
+        return srcsetUrl;
+    }
+
+    if (sanitizedHref) {
+        return sanitizedHref;
+    }
+
+    const currentSrc = sanitizeHighResUrl(innerImg.currentSrc);
+    if (currentSrc) {
+        return currentSrc;
+    }
+
+    const fallbackSrc = sanitizeHighResUrl(innerImg.src);
+    if (fallbackSrc) {
+        return fallbackSrc;
+    }
+
+    return null;
+}
+
+module.exports = {
+    resolveLinkGroupId,
+    isExplicitFallbackAllowed,
+    sanitizeHighResUrl,
+    getHighResUrl,
+    getImageDataAttributes,
+    parseSrcset,
+};

--- a/tests/js/gallery-helpers.test.js
+++ b/tests/js/gallery-helpers.test.js
@@ -1,0 +1,118 @@
+const {
+    resolveLinkGroupId,
+    isExplicitFallbackAllowed,
+    sanitizeHighResUrl,
+    getHighResUrl,
+    getImageDataAttributes,
+} = require('../../ma-galerie-automatique/assets/js/utils/gallery-helpers');
+
+describe('gallery helpers', () => {
+    describe('resolveLinkGroupId', () => {
+        test('groups by configured attribute when provided', () => {
+            const link = document.createElement('a');
+            link.setAttribute('data-custom-group', ' featured ');
+
+            const groupId = resolveLinkGroupId(link, {
+                fallbackGroupId: '__fallback__',
+                configuredGroupAttribute: 'data-custom-group',
+            });
+
+            expect(groupId).toBe('data-custom-group:featured');
+        });
+
+        test('falls back to rel attribute when custom attribute missing', () => {
+            const link = document.createElement('a');
+            link.setAttribute('rel', ' gallery-one mga-lightbox ');
+
+            const groupId = resolveLinkGroupId(link, {
+                fallbackGroupId: '__fallback__',
+                configuredGroupAttribute: '',
+            });
+
+            expect(groupId).toBe('rel:gallery-one mga-lightbox');
+        });
+
+        test('uses href fallback when configured attribute is enabled', () => {
+            const link = document.createElement('a');
+            link.setAttribute('href', ' https://example.com/image.jpg ');
+
+            const groupId = resolveLinkGroupId(link, {
+                fallbackGroupId: '__fallback__',
+                configuredGroupAttribute: 'data-custom-group',
+            });
+
+            expect(groupId).toBe('href:https://example.com/image.jpg');
+        });
+    });
+
+    describe('isExplicitFallbackAllowed', () => {
+        test('detects attachment via dataset type', () => {
+            const link = document.createElement('a');
+            link.dataset.type = 'attachment';
+
+            expect(isExplicitFallbackAllowed(link)).toBe(true);
+        });
+
+        test('detects attachment via URL parameter', () => {
+            const link = document.createElement('a');
+            link.setAttribute('href', '/media/?attachment_id=42');
+
+            expect(isExplicitFallbackAllowed(link)).toBe(true);
+        });
+    });
+
+    describe('sanitizeHighResUrl', () => {
+        test('rejects unsafe schemes', () => {
+            expect(sanitizeHighResUrl('javascript:alert(1)')).toBe('');
+            expect(sanitizeHighResUrl('data:text/plain;base64,abcd')).toBe('');
+            expect(sanitizeHighResUrl('ftp://example.com/file.jpg')).toBe('');
+        });
+
+        test('normalises protocol-relative URLs', () => {
+            const result = sanitizeHighResUrl('//example.com/image.jpg');
+            expect(result.startsWith('http')).toBe(true);
+            expect(result.endsWith('image.jpg')).toBe(true);
+        });
+    });
+
+    describe('getHighResUrl', () => {
+        test('prefers explicit high resolution dataset when fallback allowed', () => {
+            const link = document.createElement('a');
+            link.setAttribute('href', 'https://example.com/thumb.jpg');
+            link.dataset.mgaHighres = 'https://cdn.example.com/highres.jpg';
+            const img = document.createElement('img');
+            img.src = 'https://example.com/thumb.jpg';
+            link.appendChild(img);
+
+            expect(getHighResUrl(link)).toBe('https://cdn.example.com/highres.jpg');
+        });
+
+        test('falls back to currentSrc when only thumbnail sources available', () => {
+            const link = document.createElement('a');
+            link.setAttribute('href', '/not-an-image');
+            link.dataset.mgaAllowFallback = '1';
+            const img = document.createElement('img');
+            Object.defineProperty(img, 'currentSrc', {
+                value: 'https://example.com/thumb.webp',
+                configurable: true,
+            });
+            img.src = 'https://example.com/backup.jpg';
+            link.appendChild(img);
+
+            expect(getHighResUrl(link)).toBe('https://example.com/thumb.webp');
+        });
+    });
+
+    describe('getImageDataAttributes', () => {
+        test('prefers lightweight entries when excludeLarge is true', () => {
+            const img = document.createElement('img');
+            img.setAttribute('data-full-url', 'https://example.com/full.jpg');
+            img.setAttribute('data-src', 'https://example.com/thumb.jpg');
+            img.setAttribute('data-lazy-src', 'https://example.com/lazy-thumb.jpg');
+
+            const result = getImageDataAttributes(img, { excludeLarge: true });
+
+            expect(result).toBe('https://example.com/thumb.jpg');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- extract reusable gallery helper functions into `assets/js/utils/gallery-helpers.js`
- update the slideshow script to require the shared helpers
- add Jest unit tests that cover grouping behaviour, attachment detection, URL sanitising, and lightweight thumbnail selection

## Testing
- `CI=1 npm run test:js`


------
https://chatgpt.com/codex/tasks/task_e_68dc45335980832ead207f3f565e0f3e