### PR TITLE
Adjust mobile toolbar layout

### DIFF
--- a/ma-galerie-automatique/assets/css/gallery-slideshow.css
+++ b/ma-galerie-automatique/assets/css/gallery-slideshow.css
@@ -132,9 +132,22 @@
         flex-wrap: wrap;
         justify-content: space-between;
         row-gap: 8px;
+        column-gap: 8px;
     }
-    .mga-counter { width: 50%; text-align: left; }
-    .mga-toolbar { width: 50%; display: flex; justify-content: flex-end; }
+    .mga-counter {
+        flex: 1 1 150px;
+        order: 0;
+        text-align: left;
+    }
+    .mga-toolbar {
+        order: 1;
+        flex: 1 1 100%;
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 6px;
+        width: 100%;
+    }
 
     .mga-caption-container {
         width: 100%;

--- a/tests/e2e/gallery-viewer.spec.ts
+++ b/tests/e2e/gallery-viewer.spec.ts
@@ -319,6 +319,42 @@ test.describe('Gallery viewer', () => {
         }
     });
 
+    test('keeps toolbar actions accessible on a mobile viewport', async ({ page, requestUtils }) => {
+        await page.setViewportSize({ width: 320, height: 640 });
+
+        const { post, uploads, cleanup } = await createPublishedGalleryPost(
+            requestUtils,
+            'Gallery viewer mobile toolbar',
+        );
+
+        try {
+            await page.goto(post.link);
+
+            const trigger = page.locator(`a[href="${uploads[0].source_url}"]`);
+            await expect(trigger.locator('img')).toBeVisible();
+
+            await trigger.click();
+
+            const viewer = page.locator('#mga-viewer');
+            await expect(viewer).toBeVisible();
+
+            const toolbarButtons = ['#mga-play-pause', '#mga-zoom', '#mga-fullscreen', '#mga-close'];
+
+            for (const selector of toolbarButtons) {
+                const button = page.locator(selector);
+                await expect(button).toBeVisible();
+                const box = await button.boundingBox();
+                expect(box).not.toBeNull();
+                if (box) {
+                    expect(box.width).toBeGreaterThan(30);
+                    expect(box.height).toBeGreaterThan(30);
+                }
+            }
+        } finally {
+            await cleanup();
+        }
+    });
+
     test('prevents layout shift when locking scroll', async ({ page, requestUtils }) => {
         const { post, uploads, cleanup } = await createPublishedGalleryPost(requestUtils, 'Gallery viewer layout shift');
 


### PR DESCRIPTION
## Summary
- allow the portrait mobile toolbar to wrap while keeping the counter width stable
- add an end-to-end check that the toolbar buttons remain accessible on a 320×640 viewport

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68dd0ea787e4832e9d761736ef2777f8