### PR TITLE
Improve autoplay accessibility state handling

### DIFF
--- a/tests/e2e/gallery-viewer.spec.ts
+++ b/tests/e2e/gallery-viewer.spec.ts
@@ -527,4 +527,33 @@ test.describe('Gallery viewer', () => {
             await cleanup();
         }
     });
+
+    test('updates ARIA state when toggling autoplay from the toolbar', async ({ page, requestUtils }) => {
+        const { post, uploads, cleanup } = await createPublishedGalleryPost(requestUtils, 'Gallery autoplay aria state');
+
+        try {
+            await page.goto(post.link);
+
+            const trigger = page.locator(`a[href="${uploads[0].source_url}"]`);
+            await expect(trigger.locator('img')).toBeVisible();
+            await trigger.click();
+
+            const viewer = page.locator('#mga-viewer');
+            await expect(viewer).toBeVisible();
+
+            const toggle = page.locator('#mga-play-pause');
+            await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+            await expect(toggle).toHaveAttribute('aria-label', 'Lancer le diaporama');
+
+            await toggle.click();
+            await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+            await expect(toggle).toHaveAttribute('aria-label', 'Mettre le diaporama en pause');
+
+            await toggle.click();
+            await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+            await expect(toggle).toHaveAttribute('aria-label', 'Lancer le diaporama');
+        } finally {
+            await cleanup();
+        }
+    });
 });


### PR DESCRIPTION
## Summary
- initialize the play/pause control with descriptive aria attributes and update them whenever autoplay starts or stops
- expose helpers for testing and add a Jest test covering the aria state toggling logic
- extend the Playwright suite with an end-to-end check for the autoplay button aria attributes

## Testing
- `CI=1 npm test -- --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68dd0ea96518832ea7547ee6237cb736