### PR TITLE
Add accessible thumbnail controls to slideshow

### DIFF
--- a/ma-galerie-automatique/assets/css/gallery-slideshow.css
+++ b/ma-galerie-automatique/assets/css/gallery-slideshow.css
@@ -114,6 +114,26 @@
 .mga-thumbs-swiper .swiper-slide { height: 100%; width: auto; opacity: 0.5; transition: opacity 0.3s ease; cursor: pointer; border: 2px solid transparent; border-radius: 6px; box-sizing: border-box; will-change: opacity; flex-shrink: 0; }
 .mga-thumbs-swiper .swiper-slide:hover { opacity: 0.8; }
 .mga-thumbs-swiper .swiper-slide-thumb-active { opacity: 1; border-color: var(--mga-accent-color, #fff); }
+.mga-thumbs-swiper .swiper-slide .mga-thumb-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    margin: 0;
+    cursor: inherit;
+    border: 0;
+    background: none;
+    border-radius: inherit;
+}
+.mga-thumbs-swiper .swiper-slide .mga-thumb-button:focus {
+    outline: none;
+}
+.mga-thumbs-swiper .swiper-slide .mga-thumb-button:focus-visible {
+    box-shadow: 0 0 0 3px var(--mga-accent-color, #fff);
+    border-radius: inherit;
+}
 .mga-thumbs-swiper .swiper-slide img {
     height: 100%;
     width: auto; /* Correctif pour Safari */

--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -1107,6 +1107,35 @@
                 mainWrapper.textContent = '';
                 thumbsWrapper.textContent = '';
 
+                const createThumbAriaLabel = (image, position) => {
+                    if (image && image.caption) {
+                        return mgaSprintf(
+                            mga__( 'Afficher la diapositive %s : %s', 'lightbox-jlg' ),
+                            String(position),
+                            image.caption
+                        );
+                    }
+
+                    return mgaSprintf(
+                        mga__( 'Afficher la diapositive %s', 'lightbox-jlg' ),
+                        String(position)
+                    );
+                };
+
+                const handleThumbNavigation = (targetIndex) => {
+                    if (mainSwiper && !mainSwiper.destroyed) {
+                        if (typeof mainSwiper.slideToLoop === 'function') {
+                            mainSwiper.slideToLoop(targetIndex);
+                        } else if (typeof mainSwiper.slideTo === 'function') {
+                            mainSwiper.slideTo(targetIndex);
+                        }
+                    }
+
+                    if (thumbsSwiper && !thumbsSwiper.destroyed && typeof thumbsSwiper.slideTo === 'function') {
+                        thumbsSwiper.slideTo(targetIndex);
+                    }
+                };
+
                 images.forEach((img, index) => {
                     const slide = document.createElement('div');
                     slide.className = 'swiper-slide';
@@ -1132,11 +1161,42 @@
                     const thumbSlide = document.createElement('div');
                     thumbSlide.className = 'swiper-slide';
 
+                    const thumbButton = document.createElement('div');
+                    thumbButton.className = 'mga-thumb-button';
+                    thumbButton.setAttribute('tabindex', '0');
+                    thumbButton.setAttribute('role', 'button');
+                    thumbButton.setAttribute('data-slide-index', String(index));
+                    thumbButton.setAttribute('aria-label', createThumbAriaLabel(img, index + 1));
+
                     const thumbImg = document.createElement('img');
                     thumbImg.setAttribute('loading', 'lazy');
                     thumbImg.setAttribute('src', img.thumbUrl);
                     thumbImg.setAttribute('alt', img.caption);
-                    thumbSlide.appendChild(thumbImg);
+                    thumbButton.appendChild(thumbImg);
+
+                    const activateThumb = (event) => {
+                        if (event) {
+                            event.preventDefault();
+                        }
+                        handleThumbNavigation(index);
+                    };
+
+                    thumbButton.addEventListener('click', activateThumb);
+                    thumbButton.addEventListener('keydown', (event) => {
+                        if (!event) {
+                            return;
+                        }
+
+                        const { key } = event;
+                        if (key === 'Enter' || key === ' ' || key === 'Space') {
+                            activateThumb(event);
+                        } else if (key === 'Spacebar') {
+                            // Support for older browsers using deprecated key values.
+                            activateThumb(event);
+                        }
+                    });
+
+                    thumbSlide.appendChild(thumbButton);
 
                     thumbsWrapper.appendChild(thumbSlide);
                 });

--- a/tests/js/gallery-slideshow.test.js
+++ b/tests/js/gallery-slideshow.test.js
@@ -61,6 +61,65 @@ describe('updateEchoBackground', () => {
     });
 });
 
+function createSwiperMockFactory() {
+    const instances = {
+        main: null,
+        thumbs: null,
+    };
+
+    const SwiperMock = jest.fn().mockImplementation((container, config = {}) => {
+        const element = container || document.createElement('div');
+        const isMain = element.classList.contains('mga-main-swiper');
+        const instance = {
+            el: element,
+            destroyed: false,
+            params: config,
+            originalParams: config,
+            update: jest.fn(),
+            destroy: jest.fn(),
+            slides: Array.from(element.querySelectorAll('.swiper-slide')),
+            activeIndex: 0,
+            realIndex: 0,
+            slideTo: jest.fn(),
+            slideToLoop: jest.fn(),
+        };
+
+        if (isMain) {
+            instances.main = instance;
+            if (config && config.on) {
+                instance.autoplay = {
+                    running: false,
+                    start: jest.fn(() => {
+                        instance.autoplay.running = true;
+                        if (typeof config.on.autoplayStart === 'function') {
+                            config.on.autoplayStart(instance);
+                        }
+                    }),
+                    stop: jest.fn(() => {
+                        instance.autoplay.running = false;
+                        if (typeof config.on.autoplayStop === 'function') {
+                            config.on.autoplayStop(instance);
+                        }
+                    }),
+                };
+            } else {
+                instance.autoplay = null;
+            }
+        } else {
+            instances.thumbs = instance;
+            instance.autoplay = null;
+        }
+
+        if (config && config.on && typeof config.on.init === 'function') {
+            config.on.init(instance);
+        }
+
+        return instance;
+    });
+
+    return { SwiperMock, instances };
+}
+
 describe('autoplay accessibility handlers', () => {
     let testExports;
     let playPauseButton;
@@ -92,45 +151,8 @@ describe('autoplay accessibility handlers', () => {
             delay: 4,
         };
 
-        global.Swiper = jest.fn().mockImplementation((container, config) => {
-            const instance = {
-                el: container,
-                destroyed: false,
-                params: {},
-                originalParams: {},
-                update: jest.fn(),
-                slides: [],
-                activeIndex: 0,
-            };
-
-            const slide = document.createElement('div');
-            const img = document.createElement('img');
-            slide.appendChild(img);
-            instance.slides.push(slide);
-
-            if (config && config.on) {
-                instance.autoplay = {
-                    running: false,
-                    start: jest.fn(() => {
-                        instance.autoplay.running = true;
-                        if (typeof config.on.autoplayStart === 'function') {
-                            config.on.autoplayStart();
-                        }
-                    }),
-                    stop: jest.fn(() => {
-                        instance.autoplay.running = false;
-                        if (typeof config.on.autoplayStop === 'function') {
-                            config.on.autoplayStop();
-                        }
-                    }),
-                };
-                instance.realIndex = 0;
-            } else {
-                instance.autoplay = null;
-            }
-
-            return instance;
-        });
+        const { SwiperMock } = createSwiperMockFactory();
+        global.Swiper = SwiperMock;
 
         const module = require('../../ma-galerie-automatique/assets/js/gallery-slideshow');
         testExports = module.__testExports;
@@ -179,5 +201,103 @@ describe('autoplay accessibility handlers', () => {
         playPauseButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
         expect(playPauseButton.getAttribute('aria-pressed')).toBe('false');
         expect(playPauseButton.getAttribute('aria-label')).toBe('Lancer le diaporama');
+    });
+});
+
+describe('thumbnail accessibility controls', () => {
+    const originalMatchMedia = window.matchMedia;
+    let testExports;
+    let viewer;
+    let mainInstance;
+    let thumbsInstance;
+
+    beforeEach(() => {
+        jest.resetModules();
+        document.body.innerHTML = '<main></main>';
+
+        Object.defineProperty(document, 'readyState', {
+            value: 'complete',
+            configurable: true,
+        });
+
+        window.matchMedia = jest.fn().mockReturnValue({
+            matches: false,
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            addListener: jest.fn(),
+            removeListener: jest.fn(),
+        });
+
+        window.mga_settings = {
+            allowBodyFallback: true,
+            loop: false,
+            background_style: 'echo',
+            autoplay_start: false,
+            delay: 4,
+        };
+
+        const { SwiperMock, instances } = createSwiperMockFactory();
+        global.Swiper = function(...args) {
+            const createdInstance = SwiperMock(...args);
+            mainInstance = instances.main || mainInstance;
+            thumbsInstance = instances.thumbs || thumbsInstance;
+            if (createdInstance.slides.length === 0 && createdInstance.el) {
+                createdInstance.slides = Array.from(createdInstance.el.querySelectorAll('.swiper-slide'));
+            }
+            return createdInstance;
+        };
+
+        const module = require('../../ma-galerie-automatique/assets/js/gallery-slideshow');
+        testExports = module.__testExports;
+
+        viewer = testExports.getViewer();
+        testExports.openViewer([
+            {
+                highResUrl: 'https://example.com/high-1.jpg',
+                thumbUrl: 'https://example.com/thumb-1.jpg',
+                caption: 'Image 1',
+            },
+            {
+                highResUrl: 'https://example.com/high-2.jpg',
+                thumbUrl: 'https://example.com/thumb-2.jpg',
+                caption: 'Image 2',
+            },
+        ], 0);
+        mainInstance = instances.main;
+        thumbsInstance = instances.thumbs;
+    });
+
+    afterEach(() => {
+        delete window.mga_settings;
+        delete global.Swiper;
+        delete document.readyState;
+        window.matchMedia = originalMatchMedia;
+        mainInstance = null;
+        thumbsInstance = null;
+    });
+
+    it('renders focusable thumbnail controls with accessibility metadata', () => {
+        const controls = viewer.querySelectorAll('.mga-thumbs-swiper .swiper-slide .mga-thumb-button');
+        expect(controls.length).toBe(2);
+
+        const first = controls[0];
+        expect(first.getAttribute('tabindex')).toBe('0');
+        expect(first.getAttribute('role')).toBe('button');
+        expect(first.getAttribute('aria-label')).toBe('Afficher la diapositive 1 : Image 1');
+    });
+
+    it('triggers swiper navigation when activated from the keyboard', () => {
+        const controls = viewer.querySelectorAll('.mga-thumbs-swiper .swiper-slide .mga-thumb-button');
+        const secondControl = controls[1];
+
+        secondControl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+        expect(mainInstance).toBeTruthy();
+        expect(thumbsInstance).toBeTruthy();
+        expect(mainInstance.slideToLoop).toHaveBeenCalledWith(1);
+        expect(mainInstance.slideTo).not.toHaveBeenCalled();
+        if (thumbsInstance && typeof thumbsInstance.slideTo === 'function') {
+            expect(thumbsInstance.slideTo).toHaveBeenCalledWith(1);
+        }
     });
 });


### PR DESCRIPTION
## Summary
- add per-thumbnail commands with ARIA labels and keyboard activation that route through the Swiper navigation
- preserve thumbnail appearance while providing a visible focus outline for the new control
- extend unit coverage to assert accessibility attributes and keyboard-driven navigation

## Testing
- npm test
- npx wp-scripts test-unit-js tests/js/gallery-slideshow.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dd423f4ce8832e8ba252d77145fd9c