### PR TITLE
Add download control to gallery viewer

### DIFF
--- a/ma-galerie-automatique/assets/css/gallery-slideshow.css
+++ b/ma-galerie-automatique/assets/css/gallery-slideshow.css
@@ -69,6 +69,7 @@
 .mga-toolbar-button { position: relative; background: transparent; border: none; color: var(--mga-accent-color, #fff); cursor: pointer; padding: 10px; min-width: 44px; min-height: 44px; display: flex; align-items: center; justify-content: center; border-radius: 50%; transition: background-color 0.2s ease; line-height: 0; }
 .mga-toolbar-button:hover { background-color: rgba(255, 255, 255, 0.2); }
 .mga-toolbar-button .mga-icon { width: 22px; height: 22px; fill: var(--mga-accent-color, #fff); position: relative; z-index: 1; }
+.mga-toolbar-button .mga-download-icon { width: 22px; height: 22px; }
 
 .mga-timer-svg { position: absolute; top: 50%; left: 50%; width: calc(100% + 6px); height: calc(100% + 6px); transform: translate(-50%, -50%) rotate(-90deg); }
 .mga-timer-svg path { fill: none; stroke-width: 2.5; }
@@ -216,5 +217,17 @@
     }
     .mga-main-swiper {
         max-height: calc(100vh - (var(--mga-thumb-size-mobile, 70px) + 80px));
+    }
+}
+
+@media (max-width: 480px) {
+    .mga-toolbar {
+        justify-content: center;
+        gap: 8px;
+    }
+    .mga-toolbar-button {
+        min-width: 40px;
+        min-height: 40px;
+        padding: 8px;
     }
 }


### PR DESCRIPTION
## Summary
- add a download control to the lightbox toolbar that retrieves the active high-resolution image and triggers a safe download
- update slideshow styles so the new toolbar icon aligns correctly across desktop and small mobile breakpoints
- cover the new control with a Jest test to verify rendering and download handling on the active slide

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd695a72f8832eb06c5da0aba35c60