### PR TITLE
Replace thumbnail divs with buttons

### DIFF
--- a/ma-galerie-automatique/assets/css/gallery-slideshow.css
+++ b/ma-galerie-automatique/assets/css/gallery-slideshow.css
@@ -125,6 +125,9 @@
     cursor: inherit;
     border: 0;
     background: none;
+    color: inherit;
+    font: inherit;
+    appearance: none;
     border-radius: inherit;
 }
 .mga-thumbs-swiper .swiper-slide .mga-thumb-button:focus {

--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -1161,10 +1161,9 @@
                     const thumbSlide = document.createElement('div');
                     thumbSlide.className = 'swiper-slide';
 
-                    const thumbButton = document.createElement('div');
+                    const thumbButton = document.createElement('button');
+                    thumbButton.type = 'button';
                     thumbButton.className = 'mga-thumb-button';
-                    thumbButton.setAttribute('tabindex', '0');
-                    thumbButton.setAttribute('role', 'button');
                     thumbButton.setAttribute('data-slide-index', String(index));
                     thumbButton.setAttribute('aria-label', createThumbAriaLabel(img, index + 1));
 
@@ -1182,19 +1181,6 @@
                     };
 
                     thumbButton.addEventListener('click', activateThumb);
-                    thumbButton.addEventListener('keydown', (event) => {
-                        if (!event) {
-                            return;
-                        }
-
-                        const { key } = event;
-                        if (key === 'Enter' || key === ' ' || key === 'Space') {
-                            activateThumb(event);
-                        } else if (key === 'Spacebar') {
-                            // Support for older browsers using deprecated key values.
-                            activateThumb(event);
-                        }
-                    });
 
                     thumbSlide.appendChild(thumbButton);
 


### PR DESCRIPTION
## Summary
- replace thumbnail navigation divs with semantic <button type="button"> controls and rely on native keyboard activation
- adjust slideshow thumbnail styling to match the new button element defaults
- update unit tests to assert button semantics and ensure no custom keydown handlers are registered

## Testing
- npm run test:js -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68dd694d4d70832eb66756b44151a8fd