### PR TITLE
Allow closing viewer via background click

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ La visionneuse plein écran pilotée par `assets/js/gallery-slideshow.js` et mis
 - **Zoom réactif** : le bouton loupe active le zoom Swiper pour inspecter les détails, tout en autorisant le glisser tactile pour se déplacer dans l’image.
 - **Affichage plein écran** : un bouton dédié bascule le navigateur en mode plein écran et l’icône « Fermer » ou la touche Échap permet de revenir à la page.
 - **Navigation clavier et commandes rapides** : les flèches du clavier, les boutons latéraux et les interactions tactiles permettent d’avancer ou de reculer, même en mode boucle.
+- **Fermeture par clic hors image** : un clic sur l’arrière-plan de la visionneuse (en dehors du carrousel principal) ferme immédiatement le diaporama.
 - **Miniatures synchronisées** : un carrousel de vignettes met en évidence la diapositive active et permet de changer d’image d’un clic ou d’un tap.
 - **Arrière-plan immersif et préchargement** : un effet d’écho flouté anime le fond tandis que les visuels suivants sont préchargés pour fluidifier la lecture.
 - **Compatibilité avec les pièces jointes WordPress** : les galeries configurées avec `linkDestination: "attachment"` ouvrent la visionneuse sur le média original en s’appuyant sur les attributs `data-full-url` / `data-orig-file` des images.

--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -1800,6 +1800,18 @@
             if (!eventTarget) {
                 return;
             }
+            const clickedInsideViewer = viewer.contains(eventTarget);
+            const clickedInsideMainSwiper = Boolean(eventTarget.closest('.mga-main-swiper'));
+            const clickedInsideHeader = Boolean(eventTarget.closest('.mga-header'));
+            const clickedInsideThumbs = Boolean(eventTarget.closest('.mga-thumbs-swiper'));
+
+            if (
+                eventTarget === viewer ||
+                (clickedInsideViewer && !clickedInsideMainSwiper && !clickedInsideHeader && !clickedInsideThumbs)
+            ) {
+                closeViewer(viewer);
+                return;
+            }
             if (eventTarget.closest('#mga-close')) closeViewer(viewer);
             if (eventTarget.closest('#mga-play-pause')) {
                 if (mainSwiper && mainSwiper.autoplay) {

--- a/tests/e2e/gallery-viewer.spec.ts
+++ b/tests/e2e/gallery-viewer.spec.ts
@@ -263,6 +263,30 @@ test.describe('Gallery viewer', () => {
         }
     });
 
+    test('closes the viewer when clicking the background overlay', async ({ page, requestUtils }) => {
+        const { post, uploads, cleanup } = await createPublishedGalleryPost(
+            requestUtils,
+            'Gallery viewer background close',
+        );
+
+        try {
+            await page.goto(post.link);
+
+            const trigger = page.locator(`a[href="${uploads[0].source_url}"]`);
+            await expect(trigger.locator('img')).toBeVisible();
+            await trigger.click();
+
+            const viewer = page.locator('#mga-viewer');
+            await expect(viewer).toBeVisible();
+
+            await page.locator('#mga-viewer').dispatchEvent('click');
+
+            await expect(viewer).toBeHidden();
+        } finally {
+            await cleanup();
+        }
+    });
+
     test('displays the entire caption text for long captions', async ({ page, requestUtils }) => {
         const longCaption =
             'Voici une légende extrêmement longue destinée à vérifier que le texte complet est lisible ' +


### PR DESCRIPTION
## Summary
- close the viewer when clicks occur on the overlay outside the main swiper
- cover the background close behaviour with a Playwright scenario
- mention the new dismissal shortcut in the README

## Testing
- npm run test:js

------
https://chatgpt.com/codex/tasks/task_e_68dda19a023c832ea5f30b062adfb06b