### PR TITLE
Add IDs and accessibility labels to swiper navigation controls

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -916,10 +916,14 @@
 
                 const nextButton = document.createElement('div');
                 nextButton.className = 'swiper-button-next';
+                nextButton.id = 'mga-next';
+                nextButton.setAttribute('aria-label', mga__( 'Image suivante', 'lightbox-jlg' ));
                 mainSwiper.appendChild(nextButton);
 
                 const prevButton = document.createElement('div');
                 prevButton.className = 'swiper-button-prev';
+                prevButton.id = 'mga-prev';
+                prevButton.setAttribute('aria-label', mga__( 'Image précédente', 'lightbox-jlg' ));
                 mainSwiper.appendChild(prevButton);
 
                 const thumbsSwiper = document.createElement('div');


### PR DESCRIPTION
## Summary
- add mga-next and mga-prev IDs to the main swiper navigation buttons
- provide localized aria-labels on the navigation buttons for better accessibility

## Testing
- npm run test:js
- CI=1 npx wp-scripts test-e2e *(fails: Chromium could not start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dda19609dc832ea036f83cd8b18e6e