### PR TITLE
Refactor plugin into namespaced architecture

### DIFF
--- a/ma-galerie-automatique/includes/Admin/Settings.php
+++ b/ma-galerie-automatique/includes/Admin/Settings.php
@@ -1,0 +1,275 @@
+<?php
+
+namespace MaGalerieAutomatique\Admin;
+
+use MaGalerieAutomatique\Plugin;
+
+class Settings {
+    private Plugin $plugin;
+
+    public function __construct( Plugin $plugin ) {
+        $this->plugin = $plugin;
+    }
+
+    public function add_admin_menu(): void {
+        add_menu_page(
+            __( 'Lightbox - JLG', 'lightbox-jlg' ),
+            __( 'Lightbox - JLG', 'lightbox-jlg' ),
+            'manage_options',
+            'ma-galerie-automatique',
+            [ $this, 'render_options_page' ],
+            'dashicons-format-gallery',
+            26
+        );
+    }
+
+    public function register_settings(): void {
+        register_setting( 'mga_settings_group', 'mga_settings', [ $this, 'sanitize_settings' ] );
+    }
+
+    public function enqueue_assets( string $hook ): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        if ( 'toplevel_page_ma-galerie-automatique' !== $hook ) {
+            return;
+        }
+
+        wp_enqueue_style(
+            'mga-admin-style',
+            $this->plugin->get_plugin_dir_url() . 'assets/css/admin-style.css',
+            [],
+            MGA_VERSION
+        );
+
+        wp_register_script(
+            'mga-focus-utils',
+            $this->plugin->get_plugin_dir_url() . 'assets/js/utils/focus-utils.js',
+            [],
+            MGA_VERSION,
+            true
+        );
+
+        wp_register_script(
+            'mga-admin-script',
+            $this->plugin->get_plugin_dir_url() . 'assets/js/admin-script.js',
+            [ 'wp-i18n', 'mga-focus-utils' ],
+            MGA_VERSION,
+            true
+        );
+
+        wp_enqueue_script( 'mga-focus-utils' );
+        wp_enqueue_script( 'mga-admin-script' );
+
+        if ( $this->plugin->languages_directory_exists() ) {
+            wp_set_script_translations( 'mga-admin-script', 'lightbox-jlg', $this->plugin->get_languages_path() );
+        }
+    }
+
+    public function render_options_page(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        $settings = get_option( 'mga_settings', $this->get_default_settings() );
+
+        if ( defined( 'MGA_ADMIN_TEMPLATE_PATH' ) && is_readable( MGA_ADMIN_TEMPLATE_PATH ) ) {
+            include MGA_ADMIN_TEMPLATE_PATH;
+        }
+    }
+
+    public function get_default_settings(): array {
+        return [
+            'delay'              => 4,
+            'thumb_size'         => 90,
+            'thumb_size_mobile'  => 70,
+            'accent_color'       => '#ffffff',
+            'bg_opacity'         => 0.95,
+            'loop'               => true,
+            'autoplay_start'     => false,
+            'background_style'   => 'echo',
+            'z_index'            => 99999,
+            'debug_mode'         => false,
+            'groupAttribute'     => 'data-mga-gallery',
+            'contentSelectors'   => [],
+            'allowBodyFallback'  => false,
+            'tracked_post_types' => [ 'post', 'page' ],
+        ];
+    }
+
+    /**
+     * @param array|null $existing_settings
+     */
+    public function sanitize_settings( $input, $existing_settings = null ): array {
+        if ( ! is_array( $input ) ) {
+            $input = [];
+        }
+
+        $defaults = $this->get_default_settings();
+        $output   = [];
+
+        if ( null === $existing_settings ) {
+            $existing_settings = get_option( 'mga_settings', [] );
+        }
+
+        if ( ! is_array( $existing_settings ) ) {
+            $existing_settings = [];
+        }
+
+        if ( isset( $input['delay'] ) ) {
+            $delay           = (int) $input['delay'];
+            $bounded_delay   = max( 1, min( 30, $delay ) );
+            $output['delay'] = $bounded_delay;
+        } else {
+            $output['delay'] = $defaults['delay'];
+        }
+
+        if ( isset( $input['thumb_size'] ) ) {
+            $thumb_size             = (int) $input['thumb_size'];
+            $bounded_thumb_size     = max( 50, min( 150, $thumb_size ) );
+            $output['thumb_size']   = $bounded_thumb_size;
+        } else {
+            $output['thumb_size'] = $defaults['thumb_size'];
+        }
+
+        if ( isset( $input['thumb_size_mobile'] ) ) {
+            $thumb_size_mobile           = (int) $input['thumb_size_mobile'];
+            $bounded_thumb_size_mobile   = max( 40, min( 100, $thumb_size_mobile ) );
+            $output['thumb_size_mobile'] = $bounded_thumb_size_mobile;
+        } else {
+            $output['thumb_size_mobile'] = $defaults['thumb_size_mobile'];
+        }
+
+        if ( isset( $input['accent_color'] ) ) {
+            $sanitized_accent          = sanitize_hex_color( $input['accent_color'] );
+            $output['accent_color']    = $sanitized_accent ? $sanitized_accent : $defaults['accent_color'];
+        } else {
+            $output['accent_color'] = $defaults['accent_color'];
+        }
+
+        $output['bg_opacity'] = isset( $input['bg_opacity'] )
+            ? max( min( (float) $input['bg_opacity'], 1 ), 0 )
+            : $defaults['bg_opacity'];
+
+        $output['loop']           = ! empty( $input['loop'] );
+        $output['autoplay_start'] = ! empty( $input['autoplay_start'] );
+
+        $sanitize_group_attribute = static function ( $value ) use ( $defaults ) {
+            if ( ! is_string( $value ) ) {
+                return $defaults['groupAttribute'];
+            }
+
+            $trimmed = trim( $value );
+
+            if ( '' === $trimmed ) {
+                return '';
+            }
+
+            $sanitized = strtolower( preg_replace( '/[^a-z0-9_:\\-]/i', '', $trimmed ) );
+
+            return '' === $sanitized ? $defaults['groupAttribute'] : $sanitized;
+        };
+
+        if ( array_key_exists( 'groupAttribute', $input ) ) {
+            $output['groupAttribute'] = $sanitize_group_attribute( $input['groupAttribute'] );
+        } elseif ( isset( $existing_settings['groupAttribute'] ) ) {
+            $output['groupAttribute'] = $sanitize_group_attribute( $existing_settings['groupAttribute'] );
+        } else {
+            $output['groupAttribute'] = $defaults['groupAttribute'];
+        }
+
+        $allowed_bg_styles            = [ 'echo', 'blur', 'texture' ];
+        $output['background_style']   = isset( $input['background_style'] ) && in_array( $input['background_style'], $allowed_bg_styles, true )
+            ? $input['background_style']
+            : $defaults['background_style'];
+
+        if ( isset( $input['z_index'] ) ) {
+            $raw_z_index        = (int) $input['z_index'];
+            $output['z_index']  = max( 0, $raw_z_index );
+        } else {
+            $output['z_index'] = $defaults['z_index'];
+        }
+
+        $output['debug_mode'] = ! empty( $input['debug_mode'] );
+
+        $sanitize_selectors = static function ( $selectors ) {
+            $sanitized = [];
+
+            foreach ( (array) $selectors as $selector ) {
+                $clean_selector = (string) $selector;
+                $clean_selector = wp_strip_all_tags( $clean_selector );
+                $clean_selector = preg_replace( '/[\x00-\x1F\x7F]+/u', '', $clean_selector );
+                $clean_selector = preg_replace( '/\s+/u', ' ', $clean_selector );
+                $clean_selector = trim( $clean_selector );
+
+                if ( '' !== $clean_selector ) {
+                    $sanitized[] = $clean_selector;
+                }
+            }
+
+            return array_values( array_unique( $sanitized ) );
+        };
+
+        $existing_selectors = $sanitize_selectors( $defaults['contentSelectors'] );
+
+        if ( isset( $existing_settings['contentSelectors'] ) && is_array( $existing_settings['contentSelectors'] ) ) {
+            $existing_selectors = $sanitize_selectors( $existing_settings['contentSelectors'] );
+        }
+
+        if ( array_key_exists( 'contentSelectors', $input ) ) {
+            if ( is_array( $input['contentSelectors'] ) ) {
+                $output['contentSelectors'] = $sanitize_selectors( $input['contentSelectors'] );
+            } else {
+                $output['contentSelectors'] = $existing_selectors;
+            }
+        } else {
+            $output['contentSelectors'] = $existing_selectors;
+        }
+
+        $output['allowBodyFallback'] = isset( $input['allowBodyFallback'] )
+            ? (bool) $input['allowBodyFallback']
+            : (bool) $defaults['allowBodyFallback'];
+
+        $all_post_types               = get_post_types( [], 'names' );
+        $default_tracked_post_types   = array_values( array_intersect( (array) $defaults['tracked_post_types'], $all_post_types ) );
+        $existing_tracked_post_types  = $default_tracked_post_types;
+
+        if ( isset( $existing_settings['tracked_post_types'] ) && is_array( $existing_settings['tracked_post_types'] ) ) {
+            $existing_tracked_post_types = array_values(
+                array_intersect(
+                    array_map( 'sanitize_key', $existing_settings['tracked_post_types'] ),
+                    $all_post_types
+                )
+            );
+        }
+
+        if ( array_key_exists( 'tracked_post_types', $input ) ) {
+            $sanitized_tracked_post_types = [];
+
+            foreach ( (array) $input['tracked_post_types'] as $post_type ) {
+                $post_type = sanitize_key( $post_type );
+
+                if ( in_array( $post_type, $all_post_types, true ) ) {
+                    $sanitized_tracked_post_types[] = $post_type;
+                }
+            }
+
+            $output['tracked_post_types'] = array_values( array_unique( $sanitized_tracked_post_types ) );
+
+            if ( empty( $output['tracked_post_types'] ) ) {
+                $output['tracked_post_types'] = $default_tracked_post_types;
+            }
+        } else {
+            $output['tracked_post_types'] = $existing_tracked_post_types;
+        }
+
+        return $output;
+    }
+
+    public function get_sanitized_settings(): array {
+        $saved_settings = get_option( 'mga_settings', [] );
+
+        return $this->sanitize_settings( $saved_settings, $saved_settings );
+    }
+}

--- a/ma-galerie-automatique/includes/Content/Detection.php
+++ b/ma-galerie-automatique/includes/Content/Detection.php
@@ -1,0 +1,466 @@
+<?php
+
+namespace MaGalerieAutomatique\Content;
+
+use MaGalerieAutomatique\Admin\Settings;
+use MaGalerieAutomatique\Plugin;
+use WP_Post;
+
+class Detection {
+    private Plugin $plugin;
+
+    private Settings $settings;
+
+    private array $request_detection_cache = [];
+
+    public function __construct( Plugin $plugin, Settings $settings ) {
+        $this->plugin  = $plugin;
+        $this->settings = $settings;
+    }
+
+    public function should_enqueue_assets( $post ): bool {
+        $post = get_post( $post );
+
+        $force_enqueue = apply_filters( 'mga_force_enqueue', false, $post );
+
+        if ( ! $post instanceof WP_Post ) {
+            return (bool) $force_enqueue;
+        }
+
+        if ( post_password_required( $post ) ) {
+            return false;
+        }
+
+        $settings          = $this->settings->get_sanitized_settings();
+        $tracked_post_types = [];
+
+        if ( isset( $settings['tracked_post_types'] ) && is_array( $settings['tracked_post_types'] ) ) {
+            $tracked_post_types = array_map( 'sanitize_key', $settings['tracked_post_types'] );
+        }
+
+        if ( empty( $tracked_post_types ) ) {
+            $tracked_post_types = (array) $this->settings->get_default_settings()['tracked_post_types'];
+        }
+
+        $all_registered_post_types = get_post_types( [], 'names' );
+        $tracked_post_types        = array_values( array_intersect( $tracked_post_types, $all_registered_post_types ) );
+
+        $tracked_post_types = apply_filters( 'mga_tracked_post_types', $tracked_post_types, $post );
+        $tracked_post_types = array_values( array_filter( (array) $tracked_post_types ) );
+
+        if ( ! is_singular() && ! $force_enqueue ) {
+            return false;
+        }
+
+        if ( $force_enqueue ) {
+            return true;
+        }
+
+        if ( ! empty( $tracked_post_types ) && ! in_array( $post->post_type, $tracked_post_types, true ) ) {
+            return false;
+        }
+
+        $content = (string) $post->post_content;
+
+        if ( '' === trim( $content ) ) {
+            return false;
+        }
+
+        if ( isset( $this->request_detection_cache[ $post->ID ] ) ) {
+            return $this->request_detection_cache[ $post->ID ];
+        }
+
+        $has_linked_images = $this->get_cached_post_linked_images( $post );
+
+        if ( null === $has_linked_images ) {
+            $has_linked_images = $this->detect_post_linked_images( $post );
+            $this->update_post_linked_images_cache( $post->ID, $has_linked_images );
+        }
+
+        $has_linked_images = apply_filters( 'mga_post_has_linked_images', $has_linked_images, $post );
+        $has_linked_images = (bool) $has_linked_images;
+
+        $this->request_detection_cache[ $post->ID ] = $has_linked_images;
+
+        return $has_linked_images;
+    }
+
+    public function get_cached_post_linked_images( WP_Post $post ): ?bool {
+        $cached_value = get_post_meta( $post->ID, '_mga_has_linked_images', true );
+
+        if ( '' === $cached_value ) {
+            return null;
+        }
+
+        return in_array( $cached_value, [ 1, '1' ], true );
+    }
+
+    public function update_post_linked_images_cache( int $post_id, bool $has_linked_images ): void {
+        $post = get_post( $post_id );
+
+        if ( ! $post instanceof WP_Post ) {
+            return;
+        }
+
+        if ( $this->post_contains_reusable_block( $post ) ) {
+            delete_post_meta( $post_id, '_mga_has_linked_images' );
+            return;
+        }
+
+        update_post_meta( $post_id, '_mga_has_linked_images', $has_linked_images ? 1 : 0 );
+    }
+
+    public function parse_blocks_from_content( string $content ): array {
+        if ( function_exists( 'parse_blocks' ) ) {
+            return parse_blocks( $content );
+        }
+
+        if ( class_exists( '\WP_Block_Parser' ) ) {
+            $parser = new \WP_Block_Parser();
+            return $parser->parse( $content );
+        }
+
+        return [];
+    }
+
+    public function post_contains_reusable_block( WP_Post $post ): bool {
+        if ( ! function_exists( 'has_block' ) ) {
+            return false;
+        }
+
+        return has_block( 'core/block', $post );
+    }
+
+    public function blocks_include_reusable_block( array $blocks ): bool {
+        foreach ( $blocks as $block ) {
+            if ( ! is_array( $block ) ) {
+                continue;
+            }
+
+            if ( isset( $block['blockName'] ) && 'core/block' === $block['blockName'] ) {
+                return true;
+            }
+
+            if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+                if ( $this->blocks_include_reusable_block( $block['innerBlocks'] ) ) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public function detect_post_linked_images( WP_Post $post ): bool {
+        $parsed_blocks = [];
+
+        if ( has_blocks( $post ) ) {
+            $parsed_blocks = $this->parse_blocks_from_content( $post->post_content );
+        }
+
+        $default_block_names = [
+            'core/gallery',
+            'core/image',
+            'core/media-text',
+            'core/cover',
+            'core/group',
+            'core/columns',
+            'core/column',
+        ];
+
+        $linked_block_names = apply_filters( 'mga_linked_image_blocks', $default_block_names );
+
+        $allowed_block_names = apply_filters(
+            'mga_allowed_media_blocks',
+            (array) $linked_block_names,
+            $post
+        );
+
+        if ( ! is_array( $allowed_block_names ) ) {
+            $allowed_block_names = [];
+        }
+
+        $allowed_block_names = array_values( array_filter( $allowed_block_names ) );
+
+        if ( ! empty( $parsed_blocks ) ) {
+            if ( $this->blocks_include_reusable_block( $parsed_blocks ) ) {
+                delete_post_meta( $post->ID, '_mga_has_linked_images' );
+            }
+
+            if ( $this->blocks_contain_linked_media( $parsed_blocks, $allowed_block_names ) ) {
+                return true;
+            }
+        }
+
+        if ( $this->post_has_eligible_images( $post ) ) {
+            return true;
+        }
+
+        $content = $post->post_content;
+
+        if ( empty( $content ) ) {
+            return false;
+        }
+
+        $pattern = '#<a\\b[^>]*href=["\']([^"\']+\.(?:jpe?g|png|gif|bmp|webp|avif|svg))(?:\?[^"\']*)?(?:\\#[^"\']*)?["\'][^>]*>\\s*(?:<picture\\b[^>]*>.*?<img\\b[^>]*>|<img\\b[^>]*>)#is';
+
+        return (bool) preg_match( $pattern, $content );
+    }
+
+    public function refresh_post_linked_images_cache_on_save( $post_id, $post ): void {
+        if ( wp_is_post_autosave( $post_id ) || wp_is_post_revision( $post_id ) ) {
+            return;
+        }
+
+        if ( ! $post instanceof WP_Post ) {
+            return;
+        }
+
+        $settings = $this->settings->get_sanitized_settings();
+        $tracked_post_types = [];
+
+        if ( isset( $settings['tracked_post_types'] ) && is_array( $settings['tracked_post_types'] ) ) {
+            $tracked_post_types = array_map( 'sanitize_key', $settings['tracked_post_types'] );
+        }
+
+        if ( empty( $tracked_post_types ) ) {
+            $tracked_post_types = (array) $this->settings->get_default_settings()['tracked_post_types'];
+        }
+
+        $all_registered_post_types = get_post_types( [], 'names' );
+        $tracked_post_types        = array_values( array_intersect( $tracked_post_types, $all_registered_post_types ) );
+
+        $tracked_post_types = apply_filters( 'mga_tracked_post_types', $tracked_post_types, $post );
+        $tracked_post_types = array_values( array_filter( (array) $tracked_post_types ) );
+
+        if ( ! empty( $tracked_post_types ) && ! in_array( $post->post_type, $tracked_post_types, true ) ) {
+            return;
+        }
+
+        $has_linked_images = $this->detect_post_linked_images( $post );
+        $this->update_post_linked_images_cache( $post_id, $has_linked_images );
+    }
+
+    public function blocks_contain_linked_media( array $blocks, array $allowed_block_names, ?array &$visited_block_ids = null ): bool {
+        if ( ! is_array( $visited_block_ids ) ) {
+            $visited_block_ids = [];
+        }
+
+        static $reusable_block_cache = [];
+
+        foreach ( $blocks as $block ) {
+            if ( ! is_array( $block ) ) {
+                continue;
+            }
+
+            $block_name = $block['blockName'] ?? null;
+
+            if ( 'core/block' === $block_name ) {
+                $attrs = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : [];
+                $ref   = isset( $attrs['ref'] ) ? absint( $attrs['ref'] ) : 0;
+
+                if ( $ref && ! in_array( $ref, $visited_block_ids, true ) ) {
+                    $visited_block_ids[] = $ref;
+
+                    if ( array_key_exists( $ref, $reusable_block_cache ) ) {
+                        $parsed_reusable_blocks = $reusable_block_cache[ $ref ];
+                    } else {
+                        $reusable_block_cache[ $ref ] = [];
+                        $reusable_block              = get_post( $ref );
+
+                        if ( $reusable_block instanceof WP_Post && 'wp_block' === $reusable_block->post_type && ! empty( $reusable_block->post_content ) ) {
+                            $reusable_block_cache[ $ref ] = $this->parse_blocks_from_content( $reusable_block->post_content );
+                        }
+
+                        $parsed_reusable_blocks = $reusable_block_cache[ $ref ];
+                    }
+
+                    if ( ! empty( $parsed_reusable_blocks ) && $this->blocks_contain_linked_media( $parsed_reusable_blocks, $allowed_block_names, $visited_block_ids ) ) {
+                        return true;
+                    }
+                }
+
+                continue;
+            }
+
+            if ( $block_name && in_array( $block_name, $allowed_block_names, true ) ) {
+                $attrs = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : [];
+
+                if ( $this->block_attributes_link_to_media( $attrs ) ) {
+                    return true;
+                }
+            }
+
+            if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+                if ( $this->blocks_contain_linked_media( $block['innerBlocks'], $allowed_block_names, $visited_block_ids ) ) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public function block_attributes_link_to_media( array $attrs ): bool {
+        $media_destination_keys = [ 'linkDestination', 'linkTo' ];
+        $link_url_keys          = [ 'href', 'linkUrl', 'linkHref', 'imageLink', 'link' ];
+
+        foreach ( $media_destination_keys as $destination_key ) {
+            if ( isset( $attrs[ $destination_key ] ) && is_string( $attrs[ $destination_key ] ) ) {
+                if ( 'media' === $attrs[ $destination_key ] ) {
+                    return true;
+                }
+            }
+        }
+
+        foreach ( $link_url_keys as $link_key ) {
+            if ( ! isset( $attrs[ $link_key ] ) ) {
+                continue;
+            }
+
+            $link_value = $attrs[ $link_key ];
+
+            if ( is_string( $link_value ) && $this->is_image_url( $link_value ) ) {
+                return true;
+            }
+
+            if ( is_array( $link_value ) ) {
+                if ( isset( $link_value['url'] ) && is_string( $link_value['url'] ) && $this->is_image_url( $link_value['url'] ) ) {
+                    return true;
+                }
+
+                if ( $this->block_attributes_link_to_media( $link_value ) ) {
+                    return true;
+                }
+            }
+        }
+
+        foreach ( $attrs as $value ) {
+            if ( is_array( $value ) && $this->block_attributes_link_to_media( $value ) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function is_image_url( $url ): bool {
+        if ( ! is_string( $url ) || '' === $url ) {
+            return false;
+        }
+
+        $parsed_url = wp_parse_url( $url );
+
+        if ( empty( $parsed_url['path'] ) ) {
+            return false;
+        }
+
+        $extension = strtolower( pathinfo( $parsed_url['path'], PATHINFO_EXTENSION ) );
+
+        if ( '' === $extension ) {
+            return false;
+        }
+
+        $allowed_extensions = [ 'jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp', 'avif', 'svg' ];
+
+        return in_array( $extension, $allowed_extensions, true );
+    }
+
+    public function gallery_attributes_link_to_media( array $attributes ): bool {
+        if ( empty( $attributes ) ) {
+            return false;
+        }
+
+        $attributes = array_change_key_case( $attributes, CASE_LOWER );
+
+        if ( isset( $attributes['link'] ) && is_string( $attributes['link'] ) ) {
+            if ( in_array( $attributes['link'], [ 'file', 'attachment', 'media' ], true ) ) {
+                return true;
+            }
+        }
+
+        if ( isset( $attributes['linkdestination'] ) && is_string( $attributes['linkdestination'] ) ) {
+            if ( in_array( $attributes['linkdestination'], [ 'media', 'attachment' ], true ) ) {
+                return true;
+            }
+        }
+
+        if ( isset( $attributes['linkto'] ) && is_string( $attributes['linkto'] ) ) {
+            if ( in_array( $attributes['linkto'], [ 'file', 'attachment', 'media' ], true ) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function gallery_html_has_linked_media( $html ): bool {
+        if ( ! is_string( $html ) || '' === trim( $html ) ) {
+            return false;
+        }
+
+        $pattern = '#<a\\b[^>]*href=["\']([^"\']+)["\'][^>]*>\\s*(?:<picture\\b[^>]*>.*?<img\\b[^>]*>|<img\\b[^>]*>)#is';
+
+        if ( preg_match_all( $pattern, $html, $matches ) ) {
+            foreach ( $matches[1] as $href ) {
+                if ( $this->is_image_url( $href ) ) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public function post_has_eligible_images( $post = null ): bool {
+        $post = get_post( $post );
+
+        if ( ! $post instanceof WP_Post ) {
+            return false;
+        }
+
+        if ( function_exists( 'get_post_galleries_images' ) ) {
+            $galleries = get_post_galleries_images( $post );
+
+            if ( ! empty( $galleries ) ) {
+                $gallery_attributes = [];
+                $gallery_html       = [];
+
+                if ( function_exists( 'get_post_galleries' ) ) {
+                    $gallery_attributes = get_post_galleries( $post, false );
+                    $gallery_html       = get_post_galleries( $post, true );
+                }
+
+                foreach ( $galleries as $index => $images ) {
+                    if ( empty( $images ) ) {
+                        continue;
+                    }
+
+                    $has_linked_media = false;
+
+                    if ( isset( $gallery_attributes[ $index ] ) && is_array( $gallery_attributes[ $index ] ) ) {
+                        $has_linked_media = $this->gallery_attributes_link_to_media( $gallery_attributes[ $index ] );
+                    }
+
+                    if ( ! $has_linked_media && isset( $gallery_html[ $index ] ) ) {
+                        $has_linked_media = $this->gallery_html_has_linked_media( $gallery_html[ $index ] );
+                    }
+
+                    if ( $has_linked_media ) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        $content = $post->post_content;
+
+        if ( empty( $content ) ) {
+            return false;
+        }
+
+        $pattern = '#<a\\b[^>]*href=["\']([^"\']+\.(?:jpe?g|png|gif|bmp|webp|avif|svg))(?:\?[^"\']*)?(?:\\#[^"\']*)?["\'][^>]*>\\s*(?:<picture\\b[^>]*>.*?<img\\b[^>]*>|<img\\b[^>]*>)#is';
+
+        return (bool) preg_match( $pattern, $content );
+    }
+}

--- a/ma-galerie-automatique/includes/Frontend/Assets.php
+++ b/ma-galerie-automatique/includes/Frontend/Assets.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace MaGalerieAutomatique\Frontend;
+
+use MaGalerieAutomatique\Admin\Settings;
+use MaGalerieAutomatique\Content\Detection;
+use MaGalerieAutomatique\Plugin;
+use WP_Post;
+
+class Assets {
+    private Plugin $plugin;
+
+    private Settings $settings;
+
+    private Detection $detection;
+
+    public function __construct( Plugin $plugin, Settings $settings, Detection $detection ) {
+        $this->plugin    = $plugin;
+        $this->settings  = $settings;
+        $this->detection = $detection;
+    }
+
+    public function enqueue_assets(): void {
+        $post = get_post();
+
+        if ( ! $this->detection->should_enqueue_assets( $post ) ) {
+            return;
+        }
+
+        $settings        = $this->settings->get_sanitized_settings();
+        $defaults        = $this->settings->get_default_settings();
+        $languages_path  = $this->plugin->get_languages_path();
+        $has_languages   = $this->plugin->languages_directory_exists();
+        $swiper_version  = '11.1.4';
+        $local_css_url   = $this->plugin->get_plugin_dir_url() . 'assets/vendor/swiper/swiper-bundle.min.css';
+        $local_js_url    = $this->plugin->get_plugin_dir_url() . 'assets/vendor/swiper/swiper-bundle.min.js';
+        $local_css_path  = $this->plugin->get_plugin_dir_path() . 'assets/vendor/swiper/swiper-bundle.min.css';
+        $local_js_path   = $this->plugin->get_plugin_dir_path() . 'assets/vendor/swiper/swiper-bundle.min.js';
+        $cdn_swiper_css  = 'https://cdn.jsdelivr.net/npm/swiper@' . $swiper_version . '/swiper-bundle.min.css';
+        $cdn_swiper_js   = 'https://cdn.jsdelivr.net/npm/swiper@' . $swiper_version . '/swiper-bundle.min.js';
+        $asset_sources   = $this->get_swiper_asset_sources();
+        $should_refresh_sources = false;
+
+        if ( 'local' === $asset_sources['css'] && ! file_exists( $local_css_path ) ) {
+            $asset_sources['css'] = 'cdn';
+            $should_refresh_sources = true;
+        }
+
+        if ( 'local' === $asset_sources['js'] && ! file_exists( $local_js_path ) ) {
+            $asset_sources['js'] = 'cdn';
+            $should_refresh_sources = true;
+        }
+
+        if ( $should_refresh_sources ) {
+            $asset_sources = $this->refresh_swiper_asset_sources();
+        }
+
+        $swiper_css = 'local' === $asset_sources['css'] ? $local_css_url : $cdn_swiper_css;
+        $swiper_css = apply_filters( 'mga_swiper_css', $swiper_css, $swiper_version );
+
+        $swiper_js = 'local' === $asset_sources['js'] ? $local_js_url : $cdn_swiper_js;
+        $swiper_js = apply_filters( 'mga_swiper_js', $swiper_js, $swiper_version );
+
+        wp_enqueue_style( 'mga-swiper-css', $swiper_css, [], $swiper_version );
+
+        $css_sri_attributes = [];
+
+        if ( 'cdn' === $asset_sources['css'] && $swiper_css === $cdn_swiper_css ) {
+            $css_sri_attributes = [
+                'integrity'  => MGA_SWIPER_CSS_SRI_HASH,
+                'crossorigin' => 'anonymous',
+            ];
+        }
+
+        $css_sri_attributes = apply_filters( 'mga_swiper_css_sri_attributes', $css_sri_attributes, $swiper_css, $asset_sources );
+
+        foreach ( $css_sri_attributes as $attribute => $value ) {
+            if ( '' === $attribute || null === $attribute ) {
+                continue;
+            }
+
+            if ( null === $value || '' === $value ) {
+                continue;
+            }
+
+            wp_style_add_data( 'mga-swiper-css', $attribute, $value );
+        }
+
+        wp_enqueue_script( 'mga-swiper-js', $swiper_js, [], $swiper_version, true );
+
+        $js_sri_attributes = [];
+
+        if ( 'cdn' === $asset_sources['js'] && $swiper_js === $cdn_swiper_js ) {
+            $js_sri_attributes = [
+                'integrity'  => MGA_SWIPER_JS_SRI_HASH,
+                'crossorigin' => 'anonymous',
+            ];
+        }
+
+        $js_sri_attributes = apply_filters( 'mga_swiper_js_sri_attributes', $js_sri_attributes, $swiper_js, $asset_sources );
+
+        foreach ( $js_sri_attributes as $attribute => $value ) {
+            if ( '' === $attribute || null === $attribute ) {
+                continue;
+            }
+
+            if ( null === $value || '' === $value ) {
+                continue;
+            }
+
+            wp_script_add_data( 'mga-swiper-js', $attribute, $value );
+        }
+
+        wp_enqueue_style( 'mga-gallery-style', $this->plugin->get_plugin_dir_url() . 'assets/css/gallery-slideshow.css', [], MGA_VERSION );
+
+        $script_dependencies = [ 'mga-swiper-js', 'wp-i18n' ];
+
+        if ( ! empty( $settings['debug_mode'] ) ) {
+            $can_view_debug = apply_filters( 'mga_user_can_view_debug', is_user_logged_in() && current_user_can( 'manage_options' ) );
+
+            if ( $can_view_debug ) {
+                wp_register_script(
+                    'mga-debug-script',
+                    $this->plugin->get_plugin_dir_url() . 'assets/js/debug.js',
+                    [ 'wp-i18n' ],
+                    MGA_VERSION,
+                    true
+                );
+                wp_enqueue_script( 'mga-debug-script' );
+
+                if ( $has_languages ) {
+                    wp_set_script_translations( 'mga-debug-script', 'lightbox-jlg', $languages_path );
+                }
+
+                $script_dependencies[] = 'mga-debug-script';
+            }
+        }
+
+        wp_enqueue_script(
+            'mga-gallery-script',
+            $this->plugin->get_plugin_dir_url() . 'assets/js/gallery-slideshow.js',
+            $script_dependencies,
+            MGA_VERSION,
+            true
+        );
+
+        if ( $has_languages ) {
+            wp_set_script_translations( 'mga-gallery-script', 'lightbox-jlg', $languages_path );
+        }
+
+        $settings_json = wp_json_encode( $settings );
+
+        if ( false !== $settings_json ) {
+            wp_add_inline_script(
+                'mga-gallery-script',
+                'window.mga_settings = ' . $settings_json . ";\nwindow.mgaSettings = window.mga_settings;",
+                'before'
+            );
+        }
+
+        $accent_color = sanitize_hex_color( $settings['accent_color'] );
+
+        if ( ! $accent_color ) {
+            $accent_color = $defaults['accent_color'];
+        }
+
+        $dynamic_styles = sprintf(
+            ':root {--mga-thumb-size-desktop:%1$spx;--mga-thumb-size-mobile:%2$spx;--mga-accent-color:%3$s;--mga-bg-opacity:%4$s;--mga-z-index:%5$s;}',
+            absint( $settings['thumb_size'] ),
+            absint( $settings['thumb_size_mobile'] ),
+            esc_html( $accent_color ),
+            esc_html( (string) floatval( $settings['bg_opacity'] ) ),
+            esc_html( (string) intval( $settings['z_index'] ) )
+        );
+
+        wp_add_inline_style( 'mga-gallery-style', $dynamic_styles );
+    }
+
+    public function refresh_swiper_asset_sources(): array {
+        $local_swiper_css_path = $this->plugin->get_plugin_dir_path() . 'assets/vendor/swiper/swiper-bundle.min.css';
+        $local_swiper_js_path  = $this->plugin->get_plugin_dir_path() . 'assets/vendor/swiper/swiper-bundle.min.js';
+
+        $sources = [
+            'css'        => file_exists( $local_swiper_css_path ) ? 'local' : 'cdn',
+            'js'         => file_exists( $local_swiper_js_path ) ? 'local' : 'cdn',
+            'checked_at' => time(),
+        ];
+
+        $existing_sources = get_option( 'mga_swiper_asset_sources', false );
+
+        if ( false === $existing_sources ) {
+            add_option( 'mga_swiper_asset_sources', $sources, '', 'no' );
+        } else {
+            update_option( 'mga_swiper_asset_sources', $sources );
+        }
+
+        return $sources;
+    }
+
+    public function get_swiper_asset_sources(): array {
+        $sources = get_option( 'mga_swiper_asset_sources' );
+
+        if ( ! defined( 'MGA_SWIPER_SOURCES_TTL' ) ) {
+            define( 'MGA_SWIPER_SOURCES_TTL', HOUR_IN_SECONDS * 12 );
+        }
+
+        $ttl = apply_filters( 'mga_swiper_sources_ttl', MGA_SWIPER_SOURCES_TTL, $sources );
+
+        $needs_refresh = true;
+
+        if ( is_array( $sources ) && isset( $sources['css'], $sources['js'] ) ) {
+            $checked_at = isset( $sources['checked_at'] ) ? absint( $sources['checked_at'] ) : 0;
+            $is_fresh   = $checked_at && ( time() - $checked_at ) < absint( $ttl );
+
+            if ( $is_fresh ) {
+                $needs_refresh = false;
+            }
+        }
+
+        if ( $needs_refresh ) {
+            $sources = $this->refresh_swiper_asset_sources();
+        }
+
+        return $sources;
+    }
+
+    public function maybe_refresh_swiper_asset_sources( $upgrader, $options ): void {
+        if ( empty( $options['type'] ) || 'plugin' !== $options['type'] ) {
+            return;
+        }
+
+        if ( empty( $options['plugins'] ) || ! is_array( $options['plugins'] ) ) {
+            return;
+        }
+
+        $plugin_basename = plugin_basename( $this->plugin->get_plugin_file() );
+
+        if ( in_array( $plugin_basename, $options['plugins'], true ) ) {
+            $this->refresh_swiper_asset_sources();
+        }
+    }
+}

--- a/ma-galerie-automatique/includes/Plugin.php
+++ b/ma-galerie-automatique/includes/Plugin.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace MaGalerieAutomatique;
+
+use MaGalerieAutomatique\Admin\Settings;
+use MaGalerieAutomatique\Content\Detection;
+use MaGalerieAutomatique\Frontend\Assets;
+
+class Plugin {
+    private string $plugin_file;
+
+    private Settings $settings;
+
+    private Detection $detection;
+
+    private Assets $frontend_assets;
+
+    private ?bool $languages_directory_exists = null;
+
+    public function __construct( string $plugin_file ) {
+        $this->plugin_file = $plugin_file;
+        $this->settings    = new Settings( $this );
+        $this->detection   = new Detection( $this, $this->settings );
+        $this->frontend_assets = new Assets( $this, $this->settings, $this->detection );
+    }
+
+    public function register_hooks(): void {
+        add_action( 'plugins_loaded', [ $this, 'load_textdomain' ] );
+        add_action( 'wp_enqueue_scripts', [ $this->frontend_assets, 'enqueue_assets' ] );
+        add_action( 'upgrader_process_complete', [ $this->frontend_assets, 'maybe_refresh_swiper_asset_sources' ], 10, 2 );
+        add_action( 'save_post', [ $this->detection, 'refresh_post_linked_images_cache_on_save' ], 10, 2 );
+        add_action( 'admin_menu', [ $this->settings, 'add_admin_menu' ] );
+        add_action( 'admin_init', [ $this->settings, 'register_settings' ] );
+        add_action( 'admin_enqueue_scripts', [ $this->settings, 'enqueue_assets' ] );
+    }
+
+    public function activate(): void {
+        $this->frontend_assets->refresh_swiper_asset_sources();
+
+        $defaults          = $this->settings->get_default_settings();
+        $existing_settings = get_option( 'mga_settings', false );
+
+        if ( false === $existing_settings ) {
+            add_option( 'mga_settings', $defaults );
+            return;
+        }
+
+        if ( is_array( $existing_settings ) ) {
+            $merged_settings = wp_parse_args( $existing_settings, $defaults );
+            update_option( 'mga_settings', $this->settings->sanitize_settings( $merged_settings, $existing_settings ) );
+            return;
+        }
+
+        update_option( 'mga_settings', $defaults );
+    }
+
+    public function load_textdomain(): void {
+        $relative_path = $this->languages_directory_exists()
+            ? dirname( plugin_basename( $this->plugin_file ) ) . '/languages'
+            : false;
+
+        load_plugin_textdomain( 'lightbox-jlg', false, $relative_path );
+    }
+
+    public function get_plugin_file(): string {
+        return $this->plugin_file;
+    }
+
+    public function get_plugin_dir_path(): string {
+        return plugin_dir_path( $this->plugin_file );
+    }
+
+    public function get_plugin_dir_url(): string {
+        return plugin_dir_url( $this->plugin_file );
+    }
+
+    public function get_languages_path(): string {
+        return $this->get_plugin_dir_path() . 'languages';
+    }
+
+    public function languages_directory_exists(): bool {
+        if ( null === $this->languages_directory_exists ) {
+            $this->languages_directory_exists = is_dir( $this->get_languages_path() );
+        }
+
+        return $this->languages_directory_exists;
+    }
+
+    public function settings(): Settings {
+        return $this->settings;
+    }
+
+    public function detection(): Detection {
+        return $this->detection;
+    }
+
+    public function frontend_assets(): Assets {
+        return $this->frontend_assets;
+    }
+}

--- a/ma-galerie-automatique/includes/autoload.php
+++ b/ma-galerie-automatique/includes/autoload.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Simple PSR-4 autoloader for the MaGalerieAutomatique plugin.
+ */
+spl_autoload_register(
+    static function ( $class ) {
+        if ( 0 !== strpos( $class, 'MaGalerieAutomatique\\' ) ) {
+            return;
+        }
+
+        $relative = substr( $class, strlen( 'MaGalerieAutomatique\\' ) );
+        $relative_path = str_replace( '\\', '/', $relative );
+        $file = __DIR__ . '/' . $relative_path . '.php';
+
+        if ( is_readable( $file ) ) {
+            require $file;
+        }
+    }
+);

--- a/tests/phpunit/EnqueueAssetsTest.php
+++ b/tests/phpunit/EnqueueAssetsTest.php
@@ -41,7 +41,7 @@ class EnqueueAssetsTest extends WP_UnitTestCase {
             ]
         );
 
-        mga_enqueue_assets();
+        $this->assets()->enqueue_assets();
 
         $this->assertSame(
             MGA_SWIPER_CSS_SRI_HASH,
@@ -93,7 +93,7 @@ class EnqueueAssetsTest extends WP_UnitTestCase {
         add_filter( 'mga_swiper_js', $js_callback );
 
         try {
-            mga_enqueue_assets();
+            $this->assets()->enqueue_assets();
         } finally {
             remove_filter( 'mga_swiper_css', $css_callback );
             remove_filter( 'mga_swiper_js', $js_callback );
@@ -147,7 +147,7 @@ class EnqueueAssetsTest extends WP_UnitTestCase {
             ]
         );
 
-        mga_enqueue_assets();
+        $this->assets()->enqueue_assets();
 
         $dynamic_styles = wp_styles()->get_data( 'mga-gallery-style', 'after' );
         $this->assertIsArray( $dynamic_styles, 'Inline style data should be stored under the "after" key.' );
@@ -202,7 +202,7 @@ class EnqueueAssetsTest extends WP_UnitTestCase {
         add_filter( 'mga_frontend_allow_body_fallback', $filter, 10, 2 );
 
         try {
-            mga_enqueue_assets();
+            $this->assets()->enqueue_assets();
         } finally {
             remove_filter( 'mga_frontend_allow_body_fallback', $filter, 10 );
         }
@@ -256,5 +256,12 @@ class EnqueueAssetsTest extends WP_UnitTestCase {
         $this->assertIsArray( $decoded, 'The JSON payload assigned to window.mga_settings should decode to an array.' );
 
         return $decoded;
+    }
+
+    private function assets(): \MaGalerieAutomatique\Frontend\Assets {
+        $plugin = mga_plugin();
+        $this->assertInstanceOf( \MaGalerieAutomatique\Plugin::class, $plugin, 'The plugin instance should be available.' );
+
+        return $plugin->frontend_assets();
     }
 }

--- a/tests/phpunit/PostCacheMaintenanceTest.php
+++ b/tests/phpunit/PostCacheMaintenanceTest.php
@@ -32,7 +32,7 @@ class PostCacheMaintenanceTest extends WP_UnitTestCase {
             ]
         );
 
-        mga_refresh_post_linked_images_cache_on_save( $post_id, get_post( $post_id ) );
+        $this->detection()->refresh_post_linked_images_cache_on_save( $post_id, get_post( $post_id ) );
 
         $this->assertSame(
             '1',
@@ -58,7 +58,7 @@ class PostCacheMaintenanceTest extends WP_UnitTestCase {
             ]
         );
 
-        mga_refresh_post_linked_images_cache_on_save( $post_id, get_post( $post_id ) );
+        $this->detection()->refresh_post_linked_images_cache_on_save( $post_id, get_post( $post_id ) );
 
         $this->assertSame(
             '0',
@@ -87,7 +87,7 @@ class PostCacheMaintenanceTest extends WP_UnitTestCase {
 
         update_post_meta( $page_id, '_mga_has_linked_images', 'original' );
 
-        mga_refresh_post_linked_images_cache_on_save( $page_id, get_post( $page_id ) );
+        $this->detection()->refresh_post_linked_images_cache_on_save( $page_id, get_post( $page_id ) );
 
         $this->assertSame(
             'original',
@@ -122,7 +122,7 @@ class PostCacheMaintenanceTest extends WP_UnitTestCase {
 
         update_post_meta( $post_id, '_mga_has_linked_images', '1' );
 
-        mga_refresh_post_linked_images_cache_on_save( $post_id, get_post( $post_id ) );
+        $this->detection()->refresh_post_linked_images_cache_on_save( $post_id, get_post( $post_id ) );
 
         $this->assertSame(
             '',
@@ -157,7 +157,7 @@ class PostCacheMaintenanceTest extends WP_UnitTestCase {
             ]
         );
 
-        mga_refresh_post_linked_images_cache_on_save( $post_id, get_post( $post_id ) );
+        $this->detection()->refresh_post_linked_images_cache_on_save( $post_id, get_post( $post_id ) );
 
         $this->assertSame(
             '1',
@@ -192,7 +192,7 @@ class PostCacheMaintenanceTest extends WP_UnitTestCase {
             }
         );
 
-        mga_refresh_post_linked_images_cache_on_save( $post_id, get_post( $post_id ) );
+        $this->detection()->refresh_post_linked_images_cache_on_save( $post_id, get_post( $post_id ) );
 
         restore_error_handler();
 
@@ -238,11 +238,11 @@ class PostCacheMaintenanceTest extends WP_UnitTestCase {
         $post = get_post( $post_id );
         $this->assertInstanceOf( WP_Post::class, $post );
         $this->assertTrue(
-            mga_detect_post_linked_images( $post ),
+            $this->detection()->detect_post_linked_images( $post ),
             'The initial reusable block should expose linked media to the detector.'
         );
 
-        mga_refresh_post_linked_images_cache_on_save( $post_id, $post );
+        $this->detection()->refresh_post_linked_images_cache_on_save( $post_id, $post );
 
         $this->assertSame(
             '',
@@ -270,7 +270,7 @@ class PostCacheMaintenanceTest extends WP_UnitTestCase {
         $this->go_to( get_permalink( $post_id ) );
 
         $this->assertFalse(
-            mga_should_enqueue_assets( $post_id ),
+            $this->detection()->should_enqueue_assets( $post_id ),
             'Removing linked media from the reusable block should disable the enqueue logic.'
         );
 
@@ -287,6 +287,13 @@ class PostCacheMaintenanceTest extends WP_UnitTestCase {
             get_post_meta( $post_id, '_mga_has_linked_images', true ),
             'Posts referencing reusable blocks should continue to avoid caching after block updates.'
         );
+    }
+
+    private function detection(): \MaGalerieAutomatique\Content\Detection {
+        $plugin = mga_plugin();
+        $this->assertInstanceOf( \MaGalerieAutomatique\Plugin::class, $plugin, 'The plugin instance should be available.' );
+
+        return $plugin->detection();
     }
 
     private function reset_plugin_state() {

--- a/tests/phpunit/SettingsSanitizeTest.php
+++ b/tests/phpunit/SettingsSanitizeTest.php
@@ -11,7 +11,7 @@ class SettingsSanitizeTest extends WP_UnitTestCase {
      * @param array $expected_subset
      */
     public function test_sanitize_settings( $input, $existing, $expected_subset ) {
-        $result = mga_sanitize_settings( $input, $existing );
+        $result = $this->settings()->sanitize_settings( $input, $existing );
 
         foreach ( $expected_subset as $key => $expected_value ) {
             $this->assertArrayHasKey( $key, $result, sprintf( 'The %s key should exist in the sanitized settings.', $key ) );
@@ -20,12 +20,12 @@ class SettingsSanitizeTest extends WP_UnitTestCase {
     }
 
     /**
-     * Provides scenarios that exercise the mga_sanitize_settings() bounds and merge logic.
+     * Provides scenarios that exercise the sanitize_settings() bounds and merge logic.
      *
      * @return array[]
      */
     public function sanitize_settings_provider() {
-        $defaults          = mga_get_default_settings();
+        $defaults          = $this->settings()->get_default_settings();
         $all_post_types    = get_post_types( [], 'names' );
         $default_tracked   = array_values( array_intersect( (array) $defaults['tracked_post_types'], $all_post_types ) );
 
@@ -107,6 +107,13 @@ class SettingsSanitizeTest extends WP_UnitTestCase {
                 ],
             ],
         ];
+    }
+
+    private function settings(): \MaGalerieAutomatique\Admin\Settings {
+        $plugin = mga_plugin();
+        $this->assertInstanceOf( \MaGalerieAutomatique\Plugin::class, $plugin, 'The plugin instance should be available.' );
+
+        return $plugin->settings();
     }
 }
 

--- a/tests/phpunit/test-swiper-asset-sources.php
+++ b/tests/phpunit/test-swiper-asset-sources.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for mga_refresh_swiper_asset_sources().
+ * Tests for Frontend\Assets::refresh_swiper_asset_sources().
  */
 
 if ( ! function_exists( 'mga_refresh_swiper_asset_sources' ) ) {
@@ -29,7 +29,7 @@ class MGA_Swiper_Asset_Sources_Test extends WP_UnitTestCase {
             'js'  => 'cdn',
         ], '', 'no' );
 
-        mga_refresh_swiper_asset_sources();
+        $this->assets()->refresh_swiper_asset_sources();
 
         $autoload = $wpdb->get_var(
             $wpdb->prepare(
@@ -115,7 +115,7 @@ class MGA_Swiper_Asset_Sources_Test extends WP_UnitTestCase {
         delete_option( 'mga_swiper_asset_sources' );
         add_option( 'mga_swiper_asset_sources', $sentinel, '', 'no' );
 
-        $sources = mga_get_swiper_asset_sources();
+        $sources = $this->assets()->get_swiper_asset_sources();
 
         $this->assertIsArray( $sources );
         $this->assertArrayHasKey( 'checked_at', $sources );
@@ -124,5 +124,12 @@ class MGA_Swiper_Asset_Sources_Test extends WP_UnitTestCase {
         $persisted_sources = get_option( 'mga_swiper_asset_sources' );
 
         $this->assertSame( $sources, $persisted_sources, 'Refreshed sources should be persisted in the option.' );
+    }
+
+    private function assets(): \MaGalerieAutomatique\Frontend\Assets {
+        $plugin = mga_plugin();
+        $this->assertInstanceOf( \MaGalerieAutomatique\Plugin::class, $plugin, 'The plugin instance should be available.' );
+
+        return $plugin->frontend_assets();
     }
 }


### PR DESCRIPTION
## Summary
- add a PSR-4 autoloader and introduce MaGalerieAutomatique\Plugin with dedicated Admin, Content, and Frontend classes
- replace the procedural loader with a Plugin bootstrapper while keeping legacy helper wrappers for backwards compatibility
- update the PHPUnit suite to exercise the new class APIs

## Testing
- phpunit --configuration phpunit.xml.dist *(fails: command not found in container)*
- php -l ma-galerie-automatique/includes/Plugin.php
- php -l ma-galerie-automatique/includes/Admin/Settings.php
- php -l ma-galerie-automatique/includes/Content/Detection.php
- php -l ma-galerie-automatique/includes/Frontend/Assets.php
- php -l ma-galerie-automatique/ma-galerie-automatique.php


------
https://chatgpt.com/codex/tasks/task_e_68de3e4f78d4832eab47988b28877404