### PR TITLE
Add admin control for custom content selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Lightbox - JLG est un plugin WordPress qui transforme les galeries d'images en d
 - **Effets d’arrière-plan** : flou d’écho, texture ou flou en temps réel.
 - **Lecture en boucle** et **lancement automatique** du diaporama.
 - **Z‑index** de la galerie et **mode débogage**.
+- **Sélecteurs CSS personnalisés** : complétez la liste par défaut lorsque votre thème encapsule le contenu dans des conteneurs non standards (ex. `.site-main > .article-body`).
 
 ## Fonctionnalités
 La visionneuse plein écran pilotée par `assets/js/gallery-slideshow.js` et mise en forme par `assets/css/gallery-slideshow.css` offre les contrôles suivants :
@@ -58,6 +59,10 @@ Les scénarios Playwright du dépôt (par exemple `tests/e2e/gallery-viewer.spec
 ## Hooks et personnalisation
 
 Ces filtres permettent d'adapter le comportement du plugin selon vos besoins.
+
+### Quand ajuster les sélecteurs CSS ?
+
+Si votre thème n’utilise pas les classes habituelles comme `.entry-content`, `.page-content` ou `.post-content`, la détection automatique peut ignorer certaines images liées. Dans ce cas, ouvrez **Réglages → Ma Galerie Automatique** puis ajoutez vos propres sélecteurs CSS dans le champ **Sélecteurs CSS personnalisés** (un sélecteur par ligne). Le plugin combinera ces sélecteurs avec ceux fournis par défaut pour localiser les images prêtes à ouvrir la lightbox.
 
 ### `mga_swiper_css`
 - **Rôle** : modifier l'URL de la feuille de style utilisée par Swiper (locale par défaut).

--- a/ma-galerie-automatique/assets/js/admin-script.js
+++ b/ma-galerie-automatique/assets/js/admin-script.js
@@ -202,5 +202,160 @@
             (value) => value,
             (value) => mgaAdminSprintf(mgaAdmin__('%s opacity', 'lightbox-jlg'), value)
         );
+
+        const selectorsWrapper = doc.querySelector('[data-mga-content-selectors]');
+
+        if (selectorsWrapper) {
+            const selectorsList = selectorsWrapper.querySelector('[data-mga-content-selectors-list]');
+            const template = doc.getElementById('mga-content-selector-template');
+
+            if (selectorsList) {
+                const updateRemoveState = () => {
+                    const rows = selectorsList.querySelectorAll('[data-mga-content-selector-row]');
+                    const disable = rows.length <= 1;
+
+                    rows.forEach((row) => {
+                        const removeButton = row.querySelector('[data-mga-remove-selector]');
+
+                        if (removeButton) {
+                            removeButton.disabled = disable;
+                            removeButton.setAttribute('aria-disabled', disable ? 'true' : 'false');
+                        }
+                    });
+                };
+
+                const refreshRowIds = () => {
+                    const rows = selectorsList.querySelectorAll('[data-mga-content-selector-row]');
+
+                    rows.forEach((row, index) => {
+                        const input = row.querySelector('input[name="mga_settings[contentSelectors][]"]');
+
+                        if (input) {
+                            input.id = `mga-content-selector-${index}`;
+                        }
+                    });
+                };
+
+                const syncRowsState = () => {
+                    refreshRowIds();
+                    updateRemoveState();
+                };
+
+                const removeRow = (row) => {
+                    if (!row) {
+                        return;
+                    }
+
+                    const rows = selectorsList.querySelectorAll('[data-mga-content-selector-row]');
+
+                    if (rows.length <= 1) {
+                        const input = row.querySelector('input[name="mga_settings[contentSelectors][]"]');
+
+                        if (input) {
+                            input.value = '';
+                        }
+
+                        return;
+                    }
+
+                    row.remove();
+                    syncRowsState();
+                };
+
+                const bindRow = (row) => {
+                    if (!row || row.getAttribute('data-mga-selector-bound') === 'true') {
+                        return;
+                    }
+
+                    const removeButton = row.querySelector('[data-mga-remove-selector]');
+
+                    if (removeButton) {
+                        removeButton.addEventListener('click', (event) => {
+                            event.preventDefault();
+                            removeRow(row);
+                        });
+                    }
+
+                    row.setAttribute('data-mga-selector-bound', 'true');
+                };
+
+                const createRow = (value = '') => {
+                    let row = null;
+
+                    if (template && template.content) {
+                        const fragment = doc.importNode(template.content, true);
+
+                        row = fragment.firstElementChild;
+                        if (row) {
+                            bindRow(row);
+                            const input = row.querySelector('input[name="mga_settings[contentSelectors][]"]');
+
+                            if (input) {
+                                input.value = value;
+                            }
+
+                            return row;
+                        }
+                    }
+
+                    row = doc.createElement('div');
+                    row.className = 'mga-content-selectors__row';
+                    row.setAttribute('data-mga-content-selector-row', '');
+
+                    const input = doc.createElement('input');
+                    input.type = 'text';
+                    input.className = 'regular-text';
+                    input.name = 'mga_settings[contentSelectors][]';
+                    input.value = value;
+                    row.appendChild(input);
+
+                    const removeButton = doc.createElement('button');
+                    removeButton.type = 'button';
+                    removeButton.className = 'button-link mga-content-selectors__remove';
+                    removeButton.setAttribute('data-mga-remove-selector', '');
+                    removeButton.textContent = mgaAdmin__('Retirer', 'lightbox-jlg');
+                    row.appendChild(removeButton);
+
+                    bindRow(row);
+
+                    return row;
+                };
+
+                const addRow = (value = '') => {
+                    const row = createRow(value);
+
+                    if (row) {
+                        selectorsList.appendChild(row);
+
+                        const input = row.querySelector('input[name="mga_settings[contentSelectors][]"]');
+
+                        if (input) {
+                            safeFocus(input);
+                        }
+                    }
+
+                    syncRowsState();
+                };
+
+                Array.from(selectorsList.querySelectorAll('[data-mga-content-selector-row]')).forEach((row) => {
+                    bindRow(row);
+                });
+
+                if (!selectorsList.querySelector('[data-mga-content-selector-row]')) {
+                    addRow();
+                } else {
+                    syncRowsState();
+                }
+
+                const addButton = selectorsWrapper.querySelector('[data-mga-add-selector]');
+
+                if (addButton) {
+                    addButton.addEventListener('click', (event) => {
+                        event.preventDefault();
+                        addRow();
+                    });
+                }
+            }
+        }
     });
 })(typeof window !== 'undefined' ? window : globalThis);

--- a/ma-galerie-automatique/includes/Admin/Settings.php
+++ b/ma-galerie-automatique/includes/Admin/Settings.php
@@ -218,8 +218,14 @@ class Settings {
         }
 
         if ( array_key_exists( 'contentSelectors', $input ) ) {
-            if ( is_array( $input['contentSelectors'] ) ) {
-                $output['contentSelectors'] = $sanitize_selectors( $input['contentSelectors'] );
+            $raw_selectors = $input['contentSelectors'];
+
+            if ( is_string( $raw_selectors ) ) {
+                $raw_selectors = preg_split( '/\r\n|\r|\n/', $raw_selectors );
+            }
+
+            if ( is_array( $raw_selectors ) ) {
+                $output['contentSelectors'] = $sanitize_selectors( $raw_selectors );
             } else {
                 $output['contentSelectors'] = $existing_selectors;
             }

--- a/ma-galerie-automatique/includes/admin-page-template.php
+++ b/ma-galerie-automatique/includes/admin-page-template.php
@@ -189,6 +189,79 @@ $settings = wp_parse_args( $settings, $defaults );
                     </td>
                 </tr>
                 <tr>
+                    <th scope="row">
+                        <label for="mga-content-selector-0">
+                            <?php echo esc_html__( 'Sélecteurs CSS personnalisés', 'lightbox-jlg' ); ?>
+                        </label>
+                    </th>
+                    <td>
+                        <?php
+                        $configured_selectors = (array) $settings['contentSelectors'];
+
+                        if ( empty( $configured_selectors ) ) {
+                            $configured_selectors = [ '' ];
+                        }
+                        ?>
+                        <div class="mga-content-selectors" data-mga-content-selectors>
+                            <div class="mga-content-selectors__list" data-mga-content-selectors-list>
+                                <?php foreach ( $configured_selectors as $index => $selector ) : ?>
+                                    <?php
+                                    $input_id = sprintf( 'mga-content-selector-%d', (int) $index );
+                                    ?>
+                                    <div class="mga-content-selectors__row" data-mga-content-selector-row>
+                                        <input
+                                            type="text"
+                                            id="<?php echo esc_attr( $input_id ); ?>"
+                                            class="regular-text"
+                                            name="mga_settings[contentSelectors][]"
+                                            value="<?php echo esc_attr( $selector ); ?>"
+                                            placeholder="<?php echo esc_attr__( '.entry-content a[href$=".jpg"]', 'lightbox-jlg' ); ?>"
+                                        />
+                                        <button
+                                            type="button"
+                                            class="button-link mga-content-selectors__remove"
+                                            data-mga-remove-selector
+                                            aria-label="<?php echo esc_attr__( 'Supprimer ce sélecteur CSS', 'lightbox-jlg' ); ?>"
+                                        >
+                                            <?php echo esc_html__( 'Retirer', 'lightbox-jlg' ); ?>
+                                        </button>
+                                    </div>
+                                <?php endforeach; ?>
+                            </div>
+                            <p>
+                                <button
+                                    type="button"
+                                    class="button button-secondary"
+                                    data-mga-add-selector
+                                >
+                                    <?php echo esc_html__( 'Ajouter un sélecteur', 'lightbox-jlg' ); ?>
+                                </button>
+                            </p>
+                            <p class="description">
+                                <?php echo wp_kses_post( __( 'Ajoutez ici vos propres sélecteurs lorsque le contenu principal de votre thème n’utilise pas les classes par défaut (par exemple <code>.entry-content</code>). Chaque ligne ou champ correspond à un sélecteur complet utilisé pour détecter les images liées.', 'lightbox-jlg' ) ); ?>
+                            </p>
+                        </div>
+                        <template id="mga-content-selector-template">
+                            <div class="mga-content-selectors__row" data-mga-content-selector-row>
+                                <input
+                                    type="text"
+                                    class="regular-text"
+                                    name="mga_settings[contentSelectors][]"
+                                    placeholder="<?php echo esc_attr__( '.entry-content a[href$=".jpg"]', 'lightbox-jlg' ); ?>"
+                                />
+                                <button
+                                    type="button"
+                                    class="button-link mga-content-selectors__remove"
+                                    data-mga-remove-selector
+                                    aria-label="<?php echo esc_attr__( 'Supprimer ce sélecteur CSS', 'lightbox-jlg' ); ?>"
+                                >
+                                    <?php echo esc_html__( 'Retirer', 'lightbox-jlg' ); ?>
+                                </button>
+                            </div>
+                        </template>
+                    </td>
+                </tr>
+                <tr>
                     <th scope="row"><?php echo esc_html__( 'Mode de débogage', 'lightbox-jlg' ); ?></th>
                     <td>
                         <fieldset>

--- a/tests/phpunit/SettingsSanitizeTest.php
+++ b/tests/phpunit/SettingsSanitizeTest.php
@@ -102,8 +102,17 @@ class SettingsSanitizeTest extends WP_UnitTestCase {
                     'tracked_post_types' => [ 'page', 'invalid', 'post' ],
                 ],
                 [
-                    'contentSelectors'   => [ '.existing', '#persisted' ],
+                    'contentSelectors'   => [ 'body' ],
                     'tracked_post_types' => [ 'page', 'post' ],
+                ],
+            ],
+            'newline_separated_selectors' => [
+                [
+                    'contentSelectors' => ".main\n.article-content\r\n\t\n .gallery img\n",
+                ],
+                [],
+                [
+                    'contentSelectors' => [ '.main', '.article-content', '.gallery img' ],
                 ],
             ],
         ];


### PR DESCRIPTION
## Summary
- add an admin repeater control to manage custom content selectors with contextual help
- enhance the admin script and sanitization logic to support array or newline separated selector inputs
- document how and when to customise selectors and extend sanitization tests

## Testing
- ./vendor/bin/phpunit --configuration phpunit.xml.dist *(fails: vendor/bin/phpunit not available in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68de668a7728832e8e8545a1d5d829fa