### PR TITLE
Add toolbar toggle settings for gallery controls

### DIFF
--- a/ma-galerie-automatique/assets/css/gallery-slideshow.css
+++ b/ma-galerie-automatique/assets/css/gallery-slideshow.css
@@ -67,6 +67,8 @@
 .mga-toolbar { display: flex; align-items: center; gap: 10px; }
 
 .mga-toolbar-button { position: relative; background: transparent; border: none; color: var(--mga-accent-color, #fff); cursor: pointer; padding: 10px; min-width: 44px; min-height: 44px; display: flex; align-items: center; justify-content: center; border-radius: 50%; transition: background-color 0.2s ease, box-shadow 0.2s ease; line-height: 0; }
+.mga-toolbar-button[hidden],
+.mga-toolbar-button.is-hidden { display: none !important; }
 .mga-toolbar-button:focus { outline: none; }
 .mga-toolbar-button:focus-visible { box-shadow: 0 0 0 2px var(--mga-accent-color, #fff), 0 0 0 5px rgba(0, 0, 0, 0.65); }
 .mga-toolbar-button:hover { background-color: rgba(255, 255, 255, 0.2); }

--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -71,6 +71,29 @@
         const settings = window.mga_settings || {};
         const IMAGE_FILE_PATTERN = /\.(jpe?g|png|gif|bmp|webp|avif|svg)(?:\?.*)?(?:#.*)?$/i;
         const noop = () => {};
+        const normalizeFlag = (value, defaultValue = true) => {
+            if (typeof value === 'undefined') {
+                return defaultValue;
+            }
+
+            if (typeof value === 'string') {
+                const normalized = value.trim().toLowerCase();
+
+                if (['false', '0', 'no', 'off'].includes(normalized)) {
+                    return false;
+                }
+
+                if (['true', '1', 'yes', 'on'].includes(normalized)) {
+                    return true;
+                }
+            }
+
+            if (typeof value === 'number') {
+                return value !== 0;
+            }
+
+            return Boolean(value);
+        };
         const debug = window.mgaDebug || {
             enabled: false,
             init: noop,
@@ -81,6 +104,10 @@
             restartTimer: noop,
             table: noop,
         };
+        const showZoom = normalizeFlag(settings.show_zoom, true);
+        const showDownload = normalizeFlag(settings.show_download, true);
+        const showShare = normalizeFlag(settings.show_share, true);
+        const showFullscreen = normalizeFlag(settings.show_fullscreen, true);
         const SCROLL_LOCK_CLASS = 'mga-scroll-locked';
         let mainSwiper = null;
         let thumbsSwiper = null;
@@ -811,81 +838,89 @@
 
                 updateAutoplayButtonState(viewer, false);
 
-                const zoomButton = document.createElement('button');
-                zoomButton.type = 'button';
-                zoomButton.id = 'mga-zoom';
-                zoomButton.className = 'mga-toolbar-button';
-                zoomButton.setAttribute('aria-label', mga__( 'Zoom', 'lightbox-jlg' ));
-                toolbar.appendChild(zoomButton);
+                if (showZoom) {
+                    const zoomButton = document.createElement('button');
+                    zoomButton.type = 'button';
+                    zoomButton.id = 'mga-zoom';
+                    zoomButton.className = 'mga-toolbar-button';
+                    zoomButton.setAttribute('aria-label', mga__( 'Zoom', 'lightbox-jlg' ));
+                    toolbar.appendChild(zoomButton);
 
-                const zoomIcon = createSvgElement('svg', {
-                    class: 'mga-icon',
-                    viewBox: '0 0 24 24',
-                    fill: 'currentColor',
-                });
-                const zoomPrimaryPath = createSvgElement('path', {
-                    d: 'M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z',
-                });
-                const zoomSecondaryPath = createSvgElement('path', {
-                    d: 'M10 9h-1v-1H8v1H7v1h1v1h1v-1h1V9z',
-                });
-                zoomIcon.appendChild(zoomPrimaryPath);
-                zoomIcon.appendChild(zoomSecondaryPath);
-                zoomButton.appendChild(zoomIcon);
+                    const zoomIcon = createSvgElement('svg', {
+                        class: 'mga-icon',
+                        viewBox: '0 0 24 24',
+                        fill: 'currentColor',
+                    });
+                    const zoomPrimaryPath = createSvgElement('path', {
+                        d: 'M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z',
+                    });
+                    const zoomSecondaryPath = createSvgElement('path', {
+                        d: 'M10 9h-1v-1H8v1H7v1h1v1h1v-1h1V9z',
+                    });
+                    zoomIcon.appendChild(zoomPrimaryPath);
+                    zoomIcon.appendChild(zoomSecondaryPath);
+                    zoomButton.appendChild(zoomIcon);
+                }
 
-                const downloadButton = document.createElement('button');
-                downloadButton.type = 'button';
-                downloadButton.id = 'mga-download';
-                downloadButton.className = 'mga-toolbar-button';
-                downloadButton.setAttribute('aria-label', mga__( 'Télécharger l’image', 'lightbox-jlg' ));
-                toolbar.appendChild(downloadButton);
+                if (showDownload) {
+                    const downloadButton = document.createElement('button');
+                    downloadButton.type = 'button';
+                    downloadButton.id = 'mga-download';
+                    downloadButton.className = 'mga-toolbar-button';
+                    downloadButton.setAttribute('aria-label', mga__( 'Télécharger l’image', 'lightbox-jlg' ));
+                    toolbar.appendChild(downloadButton);
 
-                const downloadIcon = createSvgElement('svg', {
-                    class: 'mga-icon mga-download-icon',
-                    viewBox: '0 0 24 24',
-                    fill: 'currentColor',
-                });
-                const downloadArrow = createSvgElement('path', {
-                    d: 'M5 20h14v-2H5v2zm7-16l-5 5h3v4h4v-4h3l-5-5z',
-                });
-                downloadIcon.appendChild(downloadArrow);
-                downloadButton.appendChild(downloadIcon);
+                    const downloadIcon = createSvgElement('svg', {
+                        class: 'mga-icon mga-download-icon',
+                        viewBox: '0 0 24 24',
+                        fill: 'currentColor',
+                    });
+                    const downloadArrow = createSvgElement('path', {
+                        d: 'M5 20h14v-2H5v2zm7-16l-5 5h3v4h4v-4h3l-5-5z',
+                    });
+                    downloadIcon.appendChild(downloadArrow);
+                    downloadButton.appendChild(downloadIcon);
+                }
 
-                const shareButton = document.createElement('button');
-                shareButton.type = 'button';
-                shareButton.id = 'mga-share';
-                shareButton.className = 'mga-toolbar-button';
-                shareButton.setAttribute('aria-label', mga__( 'Partager l’image', 'lightbox-jlg' ));
-                toolbar.appendChild(shareButton);
+                if (showShare) {
+                    const shareButton = document.createElement('button');
+                    shareButton.type = 'button';
+                    shareButton.id = 'mga-share';
+                    shareButton.className = 'mga-toolbar-button';
+                    shareButton.setAttribute('aria-label', mga__( 'Partager l’image', 'lightbox-jlg' ));
+                    toolbar.appendChild(shareButton);
 
-                const shareIcon = createSvgElement('svg', {
-                    class: 'mga-icon mga-share-icon',
-                    viewBox: '0 0 24 24',
-                    fill: 'currentColor',
-                });
-                const sharePath = createSvgElement('path', {
-                    d: 'M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.02-4.11A2.99 2.99 0 0 0 18 7.91c1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.03.47.09.7L8.07 9.7A2.99 2.99 0 0 0 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.03-.82l7.05 4.12c-.06.23-.08.46-.08.7 0 1.65 1.34 2.99 3 2.99s3-1.34 3-2.99-1.34-3-3-3z',
-                });
-                shareIcon.appendChild(sharePath);
-                shareButton.appendChild(shareIcon);
+                    const shareIcon = createSvgElement('svg', {
+                        class: 'mga-icon mga-share-icon',
+                        viewBox: '0 0 24 24',
+                        fill: 'currentColor',
+                    });
+                    const sharePath = createSvgElement('path', {
+                        d: 'M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.02-4.11A2.99 2.99 0 0 0 18 7.91c1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.03.47.09.7L8.07 9.7A2.99 2.99 0 0 0 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.03-.82l7.05 4.12c-.06.23-.08.46-.08.7 0 1.65 1.34 2.99 3 2.99s3-1.34 3-2.99-1.34-3-3-3z',
+                    });
+                    shareIcon.appendChild(sharePath);
+                    shareButton.appendChild(shareIcon);
+                }
 
-                const fullscreenButton = document.createElement('button');
-                fullscreenButton.type = 'button';
-                fullscreenButton.id = 'mga-fullscreen';
-                fullscreenButton.className = 'mga-toolbar-button';
-                fullscreenButton.setAttribute('aria-label', mga__( 'Plein écran', 'lightbox-jlg' ));
-                toolbar.appendChild(fullscreenButton);
+                if (showFullscreen) {
+                    const fullscreenButton = document.createElement('button');
+                    fullscreenButton.type = 'button';
+                    fullscreenButton.id = 'mga-fullscreen';
+                    fullscreenButton.className = 'mga-toolbar-button';
+                    fullscreenButton.setAttribute('aria-label', mga__( 'Plein écran', 'lightbox-jlg' ));
+                    toolbar.appendChild(fullscreenButton);
 
-                const fullscreenIcon = createSvgElement('svg', {
-                    class: 'mga-icon',
-                    viewBox: '0 0 24 24',
-                    fill: 'currentColor',
-                });
-                const fullscreenPath = createSvgElement('path', {
-                    d: 'M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5V14h-2v3zM14 5v2h3v3h2V5h-5z',
-                });
-                fullscreenIcon.appendChild(fullscreenPath);
-                fullscreenButton.appendChild(fullscreenIcon);
+                    const fullscreenIcon = createSvgElement('svg', {
+                        class: 'mga-icon',
+                        viewBox: '0 0 24 24',
+                        fill: 'currentColor',
+                    });
+                    const fullscreenPath = createSvgElement('path', {
+                        d: 'M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5V14h-2v3zM14 5v2h3v3h2V5h-5z',
+                    });
+                    fullscreenIcon.appendChild(fullscreenPath);
+                    fullscreenButton.appendChild(fullscreenIcon);
+                }
 
                 const closeButton = document.createElement('button');
                 closeButton.type = 'button';
@@ -1829,8 +1864,8 @@
                     updateAutoplayButtonState(viewer, willRun);
                 }
             }
-            if (eventTarget.closest('#mga-zoom')) { if (mainSwiper && mainSwiper.zoom) mainSwiper.zoom.toggle(); }
-            if (eventTarget.closest('#mga-download')) {
+            if (showZoom && eventTarget.closest('#mga-zoom')) { if (mainSwiper && mainSwiper.zoom) mainSwiper.zoom.toggle(); }
+            if (showDownload && eventTarget.closest('#mga-download')) {
                 e.preventDefault();
                 const highResUrl = getActiveHighResUrl();
                 if (highResUrl) {
@@ -1842,7 +1877,7 @@
                     debug.log(mga__( "URL haute résolution introuvable pour l’image active.", 'lightbox-jlg' ), true);
                 }
             }
-            if (eventTarget.closest('#mga-share')) {
+            if (showShare && eventTarget.closest('#mga-share')) {
                 e.preventDefault();
                 const activeData = getActiveImageData();
                 if (!activeData || !activeData.image) {
@@ -1855,7 +1890,7 @@
                     debug.log(mga__( "Aucune option de partage disponible pour l’image active.", 'lightbox-jlg' ), true);
                 }
             }
-            if (eventTarget.closest('#mga-fullscreen')) {
+            if (showFullscreen && eventTarget.closest('#mga-fullscreen')) {
                 const { request: requestFullscreen, exit: exitFullscreen, element: fullscreenElement } = resolveFullscreenApi(viewer);
 
                 if (!fullscreenElement) {

--- a/ma-galerie-automatique/includes/Admin/Settings.php
+++ b/ma-galerie-automatique/includes/Admin/Settings.php
@@ -91,6 +91,10 @@ class Settings {
             'background_style'   => 'echo',
             'z_index'            => 99999,
             'debug_mode'         => false,
+            'show_zoom'          => true,
+            'show_download'      => true,
+            'show_share'         => true,
+            'show_fullscreen'    => true,
             'groupAttribute'     => 'data-mga-gallery',
             'contentSelectors'   => [],
             'allowBodyFallback'  => false,
@@ -230,6 +234,22 @@ class Settings {
         $output['allowBodyFallback'] = isset( $input['allowBodyFallback'] )
             ? (bool) $input['allowBodyFallback']
             : (bool) $defaults['allowBodyFallback'];
+
+        $resolve_toolbar_toggle = static function ( string $key ) use ( $input, $existing_settings, $defaults ) {
+            if ( is_array( $input ) && array_key_exists( $key, $input ) ) {
+                return (bool) $input[ $key ];
+            }
+
+            if ( is_array( $existing_settings ) && array_key_exists( $key, $existing_settings ) ) {
+                return (bool) $existing_settings[ $key ];
+            }
+
+            return (bool) $defaults[ $key ];
+        };
+
+        foreach ( [ 'show_zoom', 'show_download', 'show_share', 'show_fullscreen' ] as $toolbar_toggle ) {
+            $output[ $toolbar_toggle ] = $resolve_toolbar_toggle( $toolbar_toggle );
+        }
 
         $all_post_types               = get_post_types( [], 'names' );
         $default_tracked_post_types   = array_values( array_intersect( (array) $defaults['tracked_post_types'], $all_post_types ) );

--- a/ma-galerie-automatique/includes/admin-page-template.php
+++ b/ma-galerie-automatique/includes/admin-page-template.php
@@ -185,6 +185,34 @@ $settings = wp_parse_args( $settings, $defaults );
                                 <span><?php echo esc_html__( 'Autoriser le repli sur &lt;body&gt;', 'lightbox-jlg' ); ?></span>
                             </label>
                             <p class="description"><?php echo esc_html__( "Active un repli sur l'élément &lt;body&gt; si le thème ne propose pas de zone de contenu compatible.", 'lightbox-jlg' ); ?></p>
+                            <br>
+                            <input type="hidden" name="mga_settings[show_zoom]" value="0" />
+                            <label for="mga_show_zoom">
+                                <input name="mga_settings[show_zoom]" type="checkbox" id="mga_show_zoom" value="1" <?php checked( ! empty( $settings['show_zoom'] ), 1 ); ?> />
+                                <span><?php echo esc_html__( 'Afficher le bouton de zoom', 'lightbox-jlg' ); ?></span>
+                            </label>
+                            <p class="description"><?php echo esc_html__( "Permet aux visiteurs de zoomer sur l'image affichée.", 'lightbox-jlg' ); ?></p>
+                            <br>
+                            <input type="hidden" name="mga_settings[show_download]" value="0" />
+                            <label for="mga_show_download">
+                                <input name="mga_settings[show_download]" type="checkbox" id="mga_show_download" value="1" <?php checked( ! empty( $settings['show_download'] ), 1 ); ?> />
+                                <span><?php echo esc_html__( 'Afficher le bouton de téléchargement', 'lightbox-jlg' ); ?></span>
+                            </label>
+                            <p class="description"><?php echo esc_html__( "Autorise le téléchargement direct de l'image en cours.", 'lightbox-jlg' ); ?></p>
+                            <br>
+                            <input type="hidden" name="mga_settings[show_share]" value="0" />
+                            <label for="mga_show_share">
+                                <input name="mga_settings[show_share]" type="checkbox" id="mga_show_share" value="1" <?php checked( ! empty( $settings['show_share'] ), 1 ); ?> />
+                                <span><?php echo esc_html__( 'Afficher le bouton de partage', 'lightbox-jlg' ); ?></span>
+                            </label>
+                            <p class="description"><?php echo esc_html__( "Affiche le bouton de partage via le navigateur ou un nouvel onglet.", 'lightbox-jlg' ); ?></p>
+                            <br>
+                            <input type="hidden" name="mga_settings[show_fullscreen]" value="0" />
+                            <label for="mga_show_fullscreen">
+                                <input name="mga_settings[show_fullscreen]" type="checkbox" id="mga_show_fullscreen" value="1" <?php checked( ! empty( $settings['show_fullscreen'] ), 1 ); ?> />
+                                <span><?php echo esc_html__( 'Afficher le bouton plein écran', 'lightbox-jlg' ); ?></span>
+                            </label>
+                            <p class="description"><?php echo esc_html__( "Permet d'activer le mode plein écran depuis la barre d'outils.", 'lightbox-jlg' ); ?></p>
                         </fieldset>
                     </td>
                 </tr>

--- a/tests/phpunit/SettingsSanitizeTest.php
+++ b/tests/phpunit/SettingsSanitizeTest.php
@@ -51,6 +51,10 @@ class SettingsSanitizeTest extends WP_UnitTestCase {
                     'loop'           => false,
                     'autoplay_start' => true,
                     'debug_mode'     => true,
+                    'show_zoom'      => true,
+                    'show_download'  => true,
+                    'show_share'     => true,
+                    'show_fullscreen'=> true,
                 ],
             ],
             'bg_opacity_lower_bound' => [
@@ -82,6 +86,20 @@ class SettingsSanitizeTest extends WP_UnitTestCase {
                     'tracked_post_types'=> [ 'page' ],
                     'allowBodyFallback' => true,
                     'background_style'  => $defaults['background_style'],
+                ],
+            ],
+            'toolbar_toggles_casting_and_defaults' => [
+                [
+                    'show_zoom'       => '0',
+                    'show_download'   => 0,
+                    'show_share'      => '1',
+                ],
+                [],
+                [
+                    'show_zoom'       => false,
+                    'show_download'   => false,
+                    'show_share'      => true,
+                    'show_fullscreen' => $defaults['show_fullscreen'],
                 ],
             ],
             'bogus_post_types_fall_back_to_defaults' => [


### PR DESCRIPTION
## Summary
- add default toolbar visibility flags and sanitize them with existing settings
- expose checkboxes for zoom, download, share and fullscreen controls in the admin options
- conditionally render and handle toolbar controls on the front-end while adjusting CSS spacing and tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de668a446c832eb6245278e5a4ea3c