### PR TITLE
Handle numbered sprintf fallbacks

### DIFF
--- a/ma-galerie-automatique/assets/js/admin-script.js
+++ b/ma-galerie-automatique/assets/js/admin-script.js
@@ -5,11 +5,33 @@
     const mgaAdminSprintf = mgaAdminI18n && typeof mgaAdminI18n.sprintf === 'function'
         ? mgaAdminI18n.sprintf
         : ( format, ...args ) => {
-            let index = 0;
-            return format.replace(/%s/g, () => {
-                const replacement = typeof args[index] !== 'undefined' ? args[index] : '';
-                index += 1;
-                return replacement;
+            let autoIndex = 0;
+            return format.replace(/%(\d+\$)?([sd])/g, (match, position, type) => {
+                let argIndex;
+
+                if (position) {
+                    argIndex = parseInt(position, 10) - 1;
+                } else {
+                    argIndex = autoIndex;
+                    autoIndex += 1;
+                }
+
+                if (argIndex < 0 || argIndex >= args.length) {
+                    return '';
+                }
+
+                const value = args[argIndex];
+
+                if (typeof value === 'undefined') {
+                    return '';
+                }
+
+                if (type === 'd') {
+                    const coerced = parseInt(value, 10);
+                    return Number.isNaN(coerced) ? '' : String(coerced);
+                }
+
+                return String(value);
             });
         };
 

--- a/ma-galerie-automatique/assets/js/debug.js
+++ b/ma-galerie-automatique/assets/js/debug.js
@@ -6,11 +6,33 @@
     const mgaSprintf = mgaI18n && typeof mgaI18n.sprintf === 'function'
         ? mgaI18n.sprintf
         : ( format, ...args ) => {
-            let index = 0;
-            return format.replace(/%s/g, () => {
-                const replacement = typeof args[index] !== 'undefined' ? args[index] : '';
-                index += 1;
-                return replacement;
+            let autoIndex = 0;
+            return format.replace(/%(\d+\$)?([sd])/g, (match, position, type) => {
+                let argIndex;
+
+                if (position) {
+                    argIndex = parseInt(position, 10) - 1;
+                } else {
+                    argIndex = autoIndex;
+                    autoIndex += 1;
+                }
+
+                if (argIndex < 0 || argIndex >= args.length) {
+                    return '';
+                }
+
+                const value = args[argIndex];
+
+                if (typeof value === 'undefined') {
+                    return '';
+                }
+
+                if (type === 'd') {
+                    const coerced = parseInt(value, 10);
+                    return Number.isNaN(coerced) ? '' : String(coerced);
+                }
+
+                return String(value);
             });
         };
 

--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -6,11 +6,33 @@
     const mgaSprintf = mgaI18n && typeof mgaI18n.sprintf === 'function'
         ? mgaI18n.sprintf
         : ( format, ...args ) => {
-            let index = 0;
-            return format.replace(/%s/g, () => {
-                const replacement = typeof args[index] !== 'undefined' ? args[index] : '';
-                index += 1;
-                return replacement;
+            let autoIndex = 0;
+            return format.replace(/%(\d+\$)?([sd])/g, (match, position, type) => {
+                let argIndex;
+
+                if (position) {
+                    argIndex = parseInt(position, 10) - 1;
+                } else {
+                    argIndex = autoIndex;
+                    autoIndex += 1;
+                }
+
+                if (argIndex < 0 || argIndex >= args.length) {
+                    return '';
+                }
+
+                const value = args[argIndex];
+
+                if (typeof value === 'undefined') {
+                    return '';
+                }
+
+                if (type === 'd') {
+                    const coerced = parseInt(value, 10);
+                    return Number.isNaN(coerced) ? '' : String(coerced);
+                }
+
+                return String(value);
             });
         };
 


### PR DESCRIPTION
## Summary
- expand the local sprintf fallbacks to support numbered %s/%d placeholders and string/integer coercion
- align admin, debug, and slideshow scripts on the enhanced behaviour when wp.i18n is unavailable

## Testing
- node <<'NODE' … (manual environment script)

------
https://chatgpt.com/codex/tasks/task_e_68de661bef2c832e8247fccf485661fa