### PR TITLE
Add block editor preview for lightbox detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ La visionneuse plein écran pilotée par `assets/js/gallery-slideshow.js` et mis
 - **Arrière-plan immersif et préchargement** : un effet d’écho flouté anime le fond tandis que les visuels suivants sont préchargés pour fluidifier la lecture.
 - **Compatibilité avec les pièces jointes WordPress** : les galeries configurées avec `linkDestination: "attachment"` ouvrent la visionneuse sur le média original en s’appuyant sur les attributs `data-full-url` / `data-orig-file` des images.
 
+### Prévisualisation dans l’éditeur de blocs
+- **Enfilement dédié** : le hook `enqueue_block_editor_assets` charge `assets/js/block-editor-preview.js` et `assets/css/block-editor-preview.css` uniquement dans Gutenberg pour éviter l’exécution de la lightbox complète côté administration.
+- **Mise en évidence immédiate** : les images liées détectées dans les blocs `core/gallery`, `core/image` et `core/media-text` sont entourées d’un halo reprenant la couleur d’accent définie dans les réglages et une pastille « Lightbox active » apparaît dans le coin du bloc.
+- **Blocs réutilisables pris en charge** : lorsqu’un bloc réutilisable (`core/block`) contient un bloc supporté, la pastille s’affiche également sur le conteneur afin de signaler que la lightbox restera active une fois publiée.
+- **Anti-cliques accidentels** : les liens d’aperçu sont neutralisés (clic ou touche Entrée) pour éviter toute navigation hors de l’éditeur tout en offrant un rendu proche du frontal.
+
 ### Mode débogage
 - **Activation** : cochez **Activer le mode débogage** dans les réglages du plugin (onglet **Réglages → Ma Galerie Automatique**), case ajoutée par `includes/admin-page-template.php`.
 - **Panneau d’analyse** : `assets/js/debug.js` affiche un panneau flottant regroupant un chronomètre temps réel, le timer d’autoplay synchronisé au cercle de progression et un journal d’événements détaillé.

--- a/ma-galerie-automatique/assets/css/block-editor-preview.css
+++ b/ma-galerie-automatique/assets/css/block-editor-preview.css
@@ -1,0 +1,88 @@
+/*
+ * Styles d'aperçu pour l'éditeur de blocs.
+ * Permet de visualiser rapidement les images qui activeront la lightbox
+ * sans charger la visionneuse complète dans Gutenberg.
+ */
+
+:root {
+    --mga-accent-color: #c9356b;
+    --mga-bg-opacity: 0.9;
+    --mga-editor-note-bg: rgba(10, 10, 10, 0.85);
+}
+
+.block-editor-block-list__layout .block-editor-block-list__block.mga-editor-preview--lightbox {
+    position: relative;
+}
+
+.block-editor-block-list__layout .block-editor-block-list__block.mga-editor-preview--lightbox::after {
+    content: attr(data-mga-lightbox-note);
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    z-index: 3;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 10px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    background: var(--mga-editor-note-bg, rgba(10, 10, 10, 0.85));
+    color: #fff;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+    pointer-events: none;
+}
+
+.block-editor-block-list__layout a.mga-editor-preview__link {
+    position: relative;
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.block-editor-block-list__layout a.mga-editor-preview__link::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    border: 2px solid rgba(255, 255, 255, 0.35);
+    box-shadow: 0 0 0 3px var(--mga-accent-color, #c9356b);
+    opacity: 0.35;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+}
+
+.block-editor-block-list__layout a.mga-editor-preview__link:hover::after,
+.block-editor-block-list__layout a.mga-editor-preview__link:focus::after {
+    opacity: 0.55;
+}
+
+.block-editor-block-list__layout img.mga-editor-preview__image {
+    position: relative;
+    z-index: 1;
+    border-radius: 8px;
+    box-shadow:
+        0 0 0 2px rgba(255, 255, 255, 0.65),
+        0 0 0 5px var(--mga-accent-color, #c9356b),
+        0 10px 25px rgba(0, 0, 0, 0.25);
+    transition: box-shadow 0.25s ease;
+}
+
+.block-editor-block-list__layout img.mga-editor-preview__image:hover {
+    box-shadow:
+        0 0 0 2px rgba(255, 255, 255, 0.8),
+        0 0 0 6px var(--mga-accent-color, #c9356b),
+        0 12px 30px rgba(0, 0, 0, 0.3);
+}
+
+.block-editor-block-list__layout .block-editor-block-list__block.mga-editor-preview--lightbox {
+    scroll-margin: 80px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .block-editor-block-list__layout a.mga-editor-preview__link,
+    .block-editor-block-list__layout img.mga-editor-preview__image {
+        transition: none;
+    }
+}

--- a/ma-galerie-automatique/assets/js/block-editor-preview.js
+++ b/ma-galerie-automatique/assets/js/block-editor-preview.js
@@ -1,0 +1,271 @@
+(function() {
+    'use strict';
+
+    const root = window || {};
+    const wp = root.wp || {};
+    const i18n = wp.i18n || {};
+    const dataStore = wp.data || null;
+    const domReady = typeof wp.domReady === 'function'
+        ? wp.domReady
+        : function(callback) {
+            if (document.readyState === 'loading') {
+                document.addEventListener('DOMContentLoaded', callback);
+            } else {
+                callback();
+            }
+        };
+
+    const __ = typeof i18n.__ === 'function' ? i18n.__ : function(text) { return text; };
+
+    const editorSettings = root.mgaBlockEditorPreview || {};
+    const defaultNote = __('Lightbox active', 'lightbox-jlg');
+    const noteText = typeof editorSettings.noteText === 'string' && editorSettings.noteText.trim()
+        ? editorSettings.noteText.trim()
+        : defaultNote;
+    const reusableSuffix = __('Reusable block', 'lightbox-jlg');
+    const reusableNote = noteText + ' · ' + reusableSuffix;
+
+    const supportedBlocks = Array.isArray(editorSettings.supportedBlocks)
+        ? editorSettings.supportedBlocks.filter(function(name) {
+            return typeof name === 'string' && name.trim().length > 0;
+        })
+        : [];
+    const supportedSet = supportedBlocks.length ? new Set(supportedBlocks) : null;
+
+    const canvasSelector = '.block-editor-block-list__layout';
+    const blockSelector = '.block-editor-block-list__block[data-type]';
+    const linkClass = 'mga-editor-preview__link';
+    const imageClass = 'mga-editor-preview__image';
+    const activeClass = 'mga-editor-preview--lightbox';
+    const noteAttr = 'data-mga-lightbox-note';
+    const IMAGE_PATTERN = /\.(?:jpe?g|png|gif|bmp|webp|avif|svg)(?:\?.*)?(?:#.*)?$/i;
+
+    const raf = typeof root.requestAnimationFrame === 'function'
+        ? root.requestAnimationFrame.bind(root)
+        : function(callback) { return setTimeout(callback, 16); };
+
+    let rafId = null;
+    let mutationObserver = null;
+    const observerConfig = {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: [ 'href', 'class', 'data-type' ],
+    };
+
+    function scheduleUpdate() {
+        if (rafId) {
+            return;
+        }
+
+        rafId = raf(function() {
+            rafId = null;
+            updateHighlights();
+        });
+    }
+
+    function isSupportedBlockName(blockName) {
+        if (!blockName) {
+            return false;
+        }
+
+        if (!supportedSet) {
+            return true;
+        }
+
+        return supportedSet.has(blockName);
+    }
+
+    function markReusableBlocks(canvas) {
+        if (!canvas) {
+            return;
+        }
+
+        const reusableBlocks = canvas.querySelectorAll(blockSelector + '[data-type="core/block"]');
+        reusableBlocks.forEach(function(reusable) {
+            const childActive = reusable.querySelector(blockSelector + '.' + activeClass + ':not([data-type="core/block"])');
+
+            if (childActive) {
+                reusable.classList.add(activeClass);
+                reusable.setAttribute(noteAttr, reusableNote);
+            } else {
+                reusable.classList.remove(activeClass);
+                reusable.removeAttribute(noteAttr);
+            }
+        });
+    }
+
+    function cleanupCanvas(canvas) {
+        if (!canvas) {
+            return;
+        }
+
+        canvas.querySelectorAll('.' + imageClass).forEach(function(image) {
+            image.classList.remove(imageClass);
+        });
+
+        canvas.querySelectorAll('.' + linkClass).forEach(function(link) {
+            link.classList.remove(linkClass);
+        });
+
+        canvas.querySelectorAll(blockSelector + '.' + activeClass).forEach(function(block) {
+            block.classList.remove(activeClass);
+            block.removeAttribute(noteAttr);
+        });
+    }
+
+    function updateHighlights() {
+        const canvas = document.querySelector(canvasSelector);
+
+        if (!canvas) {
+            return;
+        }
+
+        if (mutationObserver) {
+            mutationObserver.disconnect();
+        }
+
+        cleanupCanvas(canvas);
+
+        const blocks = canvas.querySelectorAll(blockSelector);
+
+        blocks.forEach(function(block) {
+            const blockName = block.getAttribute('data-type') || '';
+
+            if (!isSupportedBlockName(blockName)) {
+                return;
+            }
+
+            let hasEligibleLink = false;
+
+            block.querySelectorAll('a[href]').forEach(function(anchor) {
+                if (!(anchor instanceof Element)) {
+                    return;
+                }
+
+                const href = anchor.getAttribute('href');
+
+                if (!href || !IMAGE_PATTERN.test(href)) {
+                    return;
+                }
+
+                const linkedImage = anchor.querySelector('img');
+
+                if (!linkedImage) {
+                    return;
+                }
+
+                if (anchor.closest('[data-mga-lightbox-ignore="true"]')) {
+                    return;
+                }
+
+                anchor.classList.add(linkClass);
+                linkedImage.classList.add(imageClass);
+                hasEligibleLink = true;
+            });
+
+            if (hasEligibleLink) {
+                block.classList.add(activeClass);
+                block.setAttribute(noteAttr, noteText);
+            }
+        });
+
+        markReusableBlocks(canvas);
+
+        if (mutationObserver) {
+            mutationObserver.observe(canvas, observerConfig);
+        }
+    }
+
+    function preventNavigation(event) {
+        const target = event.target;
+
+        if (!(target instanceof Element)) {
+            return;
+        }
+
+        const anchor = target.closest('a.' + linkClass);
+
+        if (!anchor) {
+            return;
+        }
+
+        if (!anchor.closest(canvasSelector)) {
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+    }
+
+    function preventKeyboardNavigation(event) {
+        if ('Enter' !== event.key) {
+            return;
+        }
+
+        const target = event.target;
+
+        if (!(target instanceof Element)) {
+            return;
+        }
+
+        const anchor = target.closest('a.' + linkClass);
+
+        if (!anchor) {
+            return;
+        }
+
+        if (!anchor.closest(canvasSelector)) {
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+    }
+
+    function observeCanvas(canvas) {
+        if (!('MutationObserver' in root) || !canvas) {
+            return;
+        }
+
+        if (!mutationObserver) {
+            mutationObserver = new MutationObserver(scheduleUpdate);
+        } else {
+            mutationObserver.disconnect();
+        }
+
+        mutationObserver.observe(canvas, observerConfig);
+    }
+
+    function bootstrap() {
+        const canvas = document.querySelector(canvasSelector);
+
+        if (!canvas) {
+            return false;
+        }
+
+        observeCanvas(canvas);
+        updateHighlights();
+
+        return true;
+    }
+
+    domReady(function() {
+        if (!bootstrap()) {
+            (function waitForCanvas() {
+                if (bootstrap()) {
+                    return;
+                }
+
+                raf(waitForCanvas);
+            })();
+        }
+
+        document.addEventListener('click', preventNavigation, true);
+        document.addEventListener('keydown', preventKeyboardNavigation, true);
+
+        if (dataStore && typeof dataStore.subscribe === 'function') {
+            dataStore.subscribe(scheduleUpdate);
+        }
+    });
+})();

--- a/ma-galerie-automatique/includes/Plugin.php
+++ b/ma-galerie-automatique/includes/Plugin.php
@@ -27,6 +27,7 @@ class Plugin {
     public function register_hooks(): void {
         add_action( 'plugins_loaded', [ $this, 'load_textdomain' ] );
         add_action( 'wp_enqueue_scripts', [ $this->frontend_assets, 'enqueue_assets' ] );
+        add_action( 'enqueue_block_editor_assets', [ $this->frontend_assets, 'enqueue_block_editor_assets' ] );
         add_action( 'upgrader_process_complete', [ $this->frontend_assets, 'maybe_refresh_swiper_asset_sources' ], 10, 2 );
         add_action( 'save_post', [ $this->detection, 'refresh_post_linked_images_cache_on_save' ], 10, 2 );
         add_action( 'admin_menu', [ $this->settings, 'add_admin_menu' ] );


### PR DESCRIPTION
## Summary
- enqueue dedicated block editor assets to preview lightbox state and mirror accent styling
- add JavaScript module to highlight eligible images, show a “Lightbox active” badge, and guard reusable blocks against accidental clicks
- document the supported Gutenberg blocks and reusable block handling in the README

## Testing
- php -l ma-galerie-automatique/includes/Frontend/Assets.php

------
https://chatgpt.com/codex/tasks/task_e_68de6d561d84832eab21c5c35c3f810a