### PR TITLE
Add WordPress color picker to accent color setting

### DIFF
--- a/ma-galerie-automatique/assets/css/admin-style.css
+++ b/ma-galerie-automatique/assets/css/admin-style.css
@@ -2,3 +2,14 @@
 .mga-admin-wrap .tab-content { display: none; }
 .mga-admin-wrap .tab-content.active { display: block; }
 #mga_thumb_size_value, #mga_bg_opacity_value { font-weight: bold; margin-left: 10px; }
+
+.mga-color-preview {
+    display: inline-block;
+    width: 28px;
+    height: 28px;
+    margin-left: 10px;
+    border-radius: 4px;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+    vertical-align: middle;
+}

--- a/ma-galerie-automatique/assets/js/admin-script.js
+++ b/ma-galerie-automatique/assets/js/admin-script.js
@@ -82,6 +82,14 @@
 
     const doc = global.document;
 
+    const isValidHexColor = (value) => {
+        if (typeof value !== 'string') {
+            return false;
+        }
+
+        return /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(value.trim());
+    };
+
     if (!doc || typeof doc.addEventListener !== 'function') {
         return;
     }
@@ -224,6 +232,50 @@
             (value) => value,
             (value) => mgaAdminSprintf(mgaAdmin__('%s opacity', 'lightbox-jlg'), value)
         );
+
+        const accentColorInput = doc.getElementById('mga_accent_color');
+        const accentColorPreview = doc.getElementById('mga_accent_color_preview');
+
+        if (accentColorInput) {
+            const defaultColorAttr = accentColorInput.getAttribute('data-default-color');
+            const fallbackColor = isValidHexColor(defaultColorAttr) ? defaultColorAttr : '#ffffff';
+
+            const applyPreviewColor = (rawColor) => {
+                const color = isValidHexColor(rawColor) ? rawColor : fallbackColor;
+
+                if (accentColorPreview) {
+                    accentColorPreview.style.backgroundColor = color;
+                }
+
+                return color;
+            };
+
+            applyPreviewColor(accentColorInput.value);
+
+            const maybeJQuery = global.jQuery;
+
+            if (maybeJQuery && typeof maybeJQuery.fn === 'object' && typeof maybeJQuery.fn.wpColorPicker === 'function') {
+                maybeJQuery(accentColorInput).wpColorPicker({
+                    change(event, ui) {
+                        const colorValue = ui && ui.color ? ui.color.toString() : event.target.value;
+                        applyPreviewColor(colorValue);
+                    },
+                    clear() {
+                        const defaultColor = accentColorInput.getAttribute('data-default-color') || fallbackColor;
+                        maybeJQuery(accentColorInput).val(defaultColor);
+                        applyPreviewColor(defaultColor);
+                    },
+                });
+
+                maybeJQuery(accentColorInput).on('input', (event) => {
+                    applyPreviewColor(event.target.value);
+                });
+            } else {
+                accentColorInput.addEventListener('input', () => {
+                    applyPreviewColor(accentColorInput.value);
+                });
+            }
+        }
 
         const selectorsWrapper = doc.querySelector('[data-mga-content-selectors]');
 

--- a/ma-galerie-automatique/includes/Admin/Settings.php
+++ b/ma-galerie-automatique/includes/Admin/Settings.php
@@ -36,12 +36,16 @@ class Settings {
             return;
         }
 
+        wp_enqueue_style( 'wp-color-picker' );
+
         wp_enqueue_style(
             'mga-admin-style',
             $this->plugin->get_plugin_dir_url() . 'assets/css/admin-style.css',
             [],
             MGA_VERSION
         );
+
+        wp_enqueue_script( 'wp-color-picker' );
 
         wp_register_script(
             'mga-focus-utils',
@@ -54,7 +58,7 @@ class Settings {
         wp_register_script(
             'mga-admin-script',
             $this->plugin->get_plugin_dir_url() . 'assets/js/admin-script.js',
-            [ 'wp-i18n', 'mga-focus-utils' ],
+            [ 'wp-i18n', 'mga-focus-utils', 'wp-color-picker' ],
             MGA_VERSION,
             true
         );

--- a/ma-galerie-automatique/includes/admin-page-template.php
+++ b/ma-galerie-automatique/includes/admin-page-template.php
@@ -104,7 +104,15 @@ $settings = wp_parse_args( $settings, $defaults );
                 <tr>
                     <th scope="row"><label for="mga_accent_color"><?php echo esc_html__( "Couleur d'accentuation", 'lightbox-jlg' ); ?></label></th>
                     <td>
-                        <input name="mga_settings[accent_color]" type="color" id="mga_accent_color" value="<?php echo esc_attr( $settings['accent_color'] ); ?>" />
+                        <input
+                            name="mga_settings[accent_color]"
+                            type="text"
+                            id="mga_accent_color"
+                            value="<?php echo esc_attr( $settings['accent_color'] ); ?>"
+                            class="regular-text wp-color-picker"
+                            data-default-color="<?php echo esc_attr( $defaults['accent_color'] ); ?>"
+                        />
+                        <span id="mga_accent_color_preview" class="mga-color-preview" aria-hidden="true"></span>
                         <p class="description"><?php echo esc_html__( 'Couleur des boutons, flèches et de la bordure de la miniature active.', 'lightbox-jlg' ); ?></p>
                     </td>
                 </tr>


### PR DESCRIPTION
## Summary
- enqueue WordPress color picker assets for the admin settings screen
- replace the accent color field with a wp-color-picker input and preview swatch
- initialize the color picker in the admin script while keeping slider previews in sync

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de6d563340832eaa041603b4c6e258