### PR TITLE
Add mobile thumbnail visibility toggle

### DIFF
--- a/ma-galerie-automatique/assets/css/gallery-slideshow.css
+++ b/ma-galerie-automatique/assets/css/gallery-slideshow.css
@@ -118,6 +118,12 @@
     max-width: 1200px;
 }
 
+@media (max-width: 768px) {
+    .mga-viewer.mga-hide-thumbs-mobile .mga-thumbs-swiper {
+        display: none;
+    }
+}
+
 .mga-thumbs-swiper .swiper-slide { height: 100%; width: auto; opacity: 0.5; transition: opacity 0.3s ease; cursor: pointer; border: 2px solid transparent; border-radius: 6px; box-sizing: border-box; will-change: opacity; flex-shrink: 0; }
 .mga-thumbs-swiper .swiper-slide:hover { opacity: 0.8; }
 .mga-thumbs-swiper .swiper-slide-thumb-active { opacity: 1; border-color: var(--mga-accent-color, #fff); }
@@ -202,10 +208,20 @@
         margin-top: calc(110px + env(safe-area-inset-top, 0px) + env(safe-area-inset-bottom, 0px));
         max-height: calc(100vh - (var(--mga-thumb-size-mobile, 70px) + 130px + env(safe-area-inset-bottom, 0px)));
     }
+    .mga-viewer.mga-hide-thumbs-mobile .mga-main-swiper {
+        max-height: calc(100vh - (130px + env(safe-area-inset-bottom, 0px)));
+    }
     .mga-thumbs-swiper {
         height: calc(var(--mga-thumb-size-mobile, 70px) + env(safe-area-inset-bottom, 0px));
     }
+    .mga-viewer.mga-hide-thumbs-mobile .mga-thumbs-swiper {
+        height: auto;
+    }
     .mga-main-swiper .swiper-button-next, .mga-main-swiper .swiper-button-prev { display: none; }
+    .mga-viewer.mga-hide-thumbs-mobile .mga-main-swiper .swiper-button-next,
+    .mga-viewer.mga-hide-thumbs-mobile .mga-main-swiper .swiper-button-prev {
+        display: flex;
+    }
 }
 
 @media (max-width: 900px) and (orientation: landscape) {
@@ -223,11 +239,18 @@
         background: linear-gradient(to top, rgba(0,0,0,0.7), transparent);
         pointer-events: none;
     }
+    .mga-viewer.mga-hide-thumbs-mobile .mga-caption-container {
+        bottom: calc(20px + env(safe-area-inset-bottom, 0px));
+        padding-bottom: calc(15px + env(safe-area-inset-bottom, 0px));
+    }
     .mga-caption {
         white-space: normal;
     }
     .mga-main-swiper {
         max-height: calc(100vh - (var(--mga-thumb-size-mobile, 70px) + 80px + env(safe-area-inset-bottom, 0px)));
+    }
+    .mga-viewer.mga-hide-thumbs-mobile .mga-main-swiper {
+        max-height: calc(100vh - (80px + env(safe-area-inset-bottom, 0px)));
     }
 }
 

--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -130,6 +130,7 @@
         const showDownload = normalizeFlag(settings.show_download, true);
         const showShare = normalizeFlag(settings.show_share, true);
         const showFullscreen = normalizeFlag(settings.show_fullscreen, true);
+        const showThumbsMobile = normalizeFlag(settings.show_thumbs_mobile, true);
         const SCROLL_LOCK_CLASS = 'mga-scroll-locked';
         let mainSwiper = null;
         let thumbsSwiper = null;
@@ -1358,6 +1359,9 @@
             viewer.className = 'mga-viewer';
             if (settings.background_style === 'blur') viewer.classList.add('mga-has-blur');
             if (settings.background_style === 'texture') viewer.classList.add('mga-has-texture');
+            if (!showThumbsMobile) {
+                viewer.classList.add('mga-hide-thumbs-mobile');
+            }
 
             try {
                 if (mainSwiper) {

--- a/ma-galerie-automatique/includes/Admin/Settings.php
+++ b/ma-galerie-automatique/includes/Admin/Settings.php
@@ -95,6 +95,7 @@ class Settings {
             'show_download'      => true,
             'show_share'         => true,
             'show_fullscreen'    => true,
+            'show_thumbs_mobile' => true,
             'groupAttribute'     => 'data-mga-gallery',
             'contentSelectors'   => [],
             'allowBodyFallback'  => false,
@@ -253,7 +254,7 @@ class Settings {
             return (bool) $defaults[ $key ];
         };
 
-        foreach ( [ 'show_zoom', 'show_download', 'show_share', 'show_fullscreen' ] as $toolbar_toggle ) {
+        foreach ( [ 'show_zoom', 'show_download', 'show_share', 'show_fullscreen', 'show_thumbs_mobile' ] as $toolbar_toggle ) {
             $output[ $toolbar_toggle ] = $resolve_toolbar_toggle( $toolbar_toggle );
         }
 

--- a/ma-galerie-automatique/includes/admin-page-template.php
+++ b/ma-galerie-automatique/includes/admin-page-template.php
@@ -99,6 +99,19 @@ $settings = wp_parse_args( $settings, $defaults );
                             <?php printf( esc_html__( '%dpx', 'lightbox-jlg' ), intval( $settings['thumb_size_mobile'] ) ); ?>
                         </output>
                         <p class="description"><?php echo esc_html__( "Ajustez la hauteur des miniatures en bas de la galerie pour chaque type d'appareil.", 'lightbox-jlg' ); ?></p>
+                        <br>
+                        <input type="hidden" name="mga_settings[show_thumbs_mobile]" value="0" />
+                        <label for="mga_show_thumbs_mobile">
+                            <input
+                                name="mga_settings[show_thumbs_mobile]"
+                                type="checkbox"
+                                id="mga_show_thumbs_mobile"
+                                value="1"
+                                <?php checked( ! empty( $settings['show_thumbs_mobile'] ), 1 ); ?>
+                            />
+                            <span><?php echo esc_html__( 'Afficher les miniatures sur mobile', 'lightbox-jlg' ); ?></span>
+                        </label>
+                        <p class="description"><?php echo esc_html__( 'Décochez pour masquer les miniatures sous 768px. Les flèches de navigation resteront visibles afin de permettre le changement d’image.', 'lightbox-jlg' ); ?></p>
                     </td>
                 </tr>
                 <tr>

--- a/tests/phpunit/SettingsSanitizeTest.php
+++ b/tests/phpunit/SettingsSanitizeTest.php
@@ -55,6 +55,7 @@ class SettingsSanitizeTest extends WP_UnitTestCase {
                     'show_download'  => true,
                     'show_share'     => true,
                     'show_fullscreen'=> true,
+                    'show_thumbs_mobile' => true,
                 ],
             ],
             'bg_opacity_lower_bound' => [
@@ -100,6 +101,18 @@ class SettingsSanitizeTest extends WP_UnitTestCase {
                     'show_download'   => false,
                     'show_share'      => true,
                     'show_fullscreen' => $defaults['show_fullscreen'],
+                    'show_thumbs_mobile' => $defaults['show_thumbs_mobile'],
+                ],
+            ],
+            'show_thumbs_mobile_toggle' => [
+                [
+                    'show_thumbs_mobile' => '0',
+                ],
+                [
+                    'show_thumbs_mobile' => true,
+                ],
+                [
+                    'show_thumbs_mobile' => false,
                 ],
             ],
             'bogus_post_types_fall_back_to_defaults' => [


### PR DESCRIPTION
## Summary
- add a setting to control thumbnail visibility on mobile and surface it in the admin UI
- apply the new preference on the viewer and style a mobile-only hide state with accessible navigation
- extend settings sanitization tests to cover the new option

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de6d561cb8832ebd4d410f172a4121