### PR TITLE
Add configurable toolbar toggles for gallery controls

### DIFF
--- a/ma-galerie-automatique/assets/css/admin-style.css
+++ b/ma-galerie-automatique/assets/css/admin-style.css
@@ -2,3 +2,9 @@
 .mga-admin-wrap .tab-content { display: none; }
 .mga-admin-wrap .tab-content.active { display: block; }
 #mga_thumb_size_value, #mga_bg_opacity_value { font-weight: bold; margin-left: 10px; }
+.mga-admin-wrap .mga-option-toggle { margin-bottom: 12px; }
+.mga-admin-wrap .mga-option-toggle:last-child { margin-bottom: 0; }
+.mga-admin-wrap .mga-option-toggle label { display: flex; align-items: center; gap: 8px; font-weight: 600; }
+.mga-admin-wrap .mga-option-toggle .description { margin: 4px 0 0 26px; }
+.mga-admin-wrap .mga-toolbar-options { display: grid; gap: 12px; margin-top: 16px; padding-top: 16px; border-top: 1px solid rgba(0, 0, 0, 0.1); }
+.mga-admin-wrap .mga-toolbar-options .description { margin-left: 26px; }

--- a/ma-galerie-automatique/assets/css/gallery-slideshow.css
+++ b/ma-galerie-automatique/assets/css/gallery-slideshow.css
@@ -64,7 +64,8 @@
     white-space: normal;
     overflow-wrap: anywhere;
 }
-.mga-toolbar { display: flex; align-items: center; gap: 10px; }
+.mga-toolbar { display: flex; align-items: center; gap: var(--mga-toolbar-gap, 10px); }
+.mga-toolbar:empty { display: none; }
 
 .mga-toolbar-button { position: relative; background: transparent; border: none; color: var(--mga-accent-color, #fff); cursor: pointer; padding: 10px; min-width: 44px; min-height: 44px; display: flex; align-items: center; justify-content: center; border-radius: 50%; transition: background-color 0.2s ease, box-shadow 0.2s ease; line-height: 0; }
 .mga-toolbar-button[hidden],
@@ -234,7 +235,7 @@
 @media (max-width: 480px) {
     .mga-toolbar {
         justify-content: center;
-        gap: 8px;
+        --mga-toolbar-gap: 8px;
     }
     .mga-toolbar-button {
         min-width: 40px;

--- a/ma-galerie-automatique/includes/admin-page-template.php
+++ b/ma-galerie-automatique/includes/admin-page-template.php
@@ -168,51 +168,61 @@ $settings = wp_parse_args( $settings, $defaults );
                     <th scope="row"><?php echo esc_html__( 'Options diverses', 'lightbox-jlg' ); ?></th>
                     <td>
                         <fieldset>
-                            <label for="mga_loop">
-                                <input name="mga_settings[loop]" type="checkbox" id="mga_loop" value="1" <?php checked( ! empty( $settings['loop'] ), 1 ); ?> />
-                                <span><?php echo esc_html__( 'Lecture en boucle', 'lightbox-jlg' ); ?></span>
-                            </label>
-                            <p class="description"><?php echo esc_html__( 'Permet au diaporama de recommencer au début après la dernière image.', 'lightbox-jlg' ); ?></p>
-                            <br>
-                            <label for="mga_autoplay_start">
-                                <input name="mga_settings[autoplay_start]" type="checkbox" id="mga_autoplay_start" value="1" <?php checked( ! empty( $settings['autoplay_start'] ), 1 ); ?> />
-                                <span><?php echo esc_html__( 'Lancement auto. du diaporama', 'lightbox-jlg' ); ?></span>
-                            </label>
-                            <p class="description"><?php echo esc_html__( "Si coché, le diaporama démarre automatiquement à l'ouverture de la galerie.", 'lightbox-jlg' ); ?></p>
-                            <br>
-                            <label for="mga_allow_body_fallback">
-                                <input name="mga_settings[allowBodyFallback]" type="checkbox" id="mga_allow_body_fallback" value="1" <?php checked( ! empty( $settings['allowBodyFallback'] ), 1 ); ?> />
-                                <span><?php echo esc_html__( 'Autoriser le repli sur &lt;body&gt;', 'lightbox-jlg' ); ?></span>
-                            </label>
-                            <p class="description"><?php echo esc_html__( "Active un repli sur l'élément &lt;body&gt; si le thème ne propose pas de zone de contenu compatible.", 'lightbox-jlg' ); ?></p>
-                            <br>
-                            <input type="hidden" name="mga_settings[show_zoom]" value="0" />
-                            <label for="mga_show_zoom">
-                                <input name="mga_settings[show_zoom]" type="checkbox" id="mga_show_zoom" value="1" <?php checked( ! empty( $settings['show_zoom'] ), 1 ); ?> />
-                                <span><?php echo esc_html__( 'Afficher le bouton de zoom', 'lightbox-jlg' ); ?></span>
-                            </label>
-                            <p class="description"><?php echo esc_html__( "Permet aux visiteurs de zoomer sur l'image affichée.", 'lightbox-jlg' ); ?></p>
-                            <br>
-                            <input type="hidden" name="mga_settings[show_download]" value="0" />
-                            <label for="mga_show_download">
-                                <input name="mga_settings[show_download]" type="checkbox" id="mga_show_download" value="1" <?php checked( ! empty( $settings['show_download'] ), 1 ); ?> />
-                                <span><?php echo esc_html__( 'Afficher le bouton de téléchargement', 'lightbox-jlg' ); ?></span>
-                            </label>
-                            <p class="description"><?php echo esc_html__( "Autorise le téléchargement direct de l'image en cours.", 'lightbox-jlg' ); ?></p>
-                            <br>
-                            <input type="hidden" name="mga_settings[show_share]" value="0" />
-                            <label for="mga_show_share">
-                                <input name="mga_settings[show_share]" type="checkbox" id="mga_show_share" value="1" <?php checked( ! empty( $settings['show_share'] ), 1 ); ?> />
-                                <span><?php echo esc_html__( 'Afficher le bouton de partage', 'lightbox-jlg' ); ?></span>
-                            </label>
-                            <p class="description"><?php echo esc_html__( "Affiche le bouton de partage via le navigateur ou un nouvel onglet.", 'lightbox-jlg' ); ?></p>
-                            <br>
-                            <input type="hidden" name="mga_settings[show_fullscreen]" value="0" />
-                            <label for="mga_show_fullscreen">
-                                <input name="mga_settings[show_fullscreen]" type="checkbox" id="mga_show_fullscreen" value="1" <?php checked( ! empty( $settings['show_fullscreen'] ), 1 ); ?> />
-                                <span><?php echo esc_html__( 'Afficher le bouton plein écran', 'lightbox-jlg' ); ?></span>
-                            </label>
-                            <p class="description"><?php echo esc_html__( "Permet d'activer le mode plein écran depuis la barre d'outils.", 'lightbox-jlg' ); ?></p>
+                            <div class="mga-option-toggle">
+                                <label for="mga_loop">
+                                    <input name="mga_settings[loop]" type="checkbox" id="mga_loop" value="1" <?php checked( ! empty( $settings['loop'] ), 1 ); ?> />
+                                    <span><?php echo esc_html__( 'Lecture en boucle', 'lightbox-jlg' ); ?></span>
+                                </label>
+                                <p class="description"><?php echo esc_html__( 'Permet au diaporama de recommencer au début après la dernière image.', 'lightbox-jlg' ); ?></p>
+                            </div>
+                            <div class="mga-option-toggle">
+                                <label for="mga_autoplay_start">
+                                    <input name="mga_settings[autoplay_start]" type="checkbox" id="mga_autoplay_start" value="1" <?php checked( ! empty( $settings['autoplay_start'] ), 1 ); ?> />
+                                    <span><?php echo esc_html__( 'Lancement auto. du diaporama', 'lightbox-jlg' ); ?></span>
+                                </label>
+                                <p class="description"><?php echo esc_html__( "Si coché, le diaporama démarre automatiquement à l'ouverture de la galerie.", 'lightbox-jlg' ); ?></p>
+                            </div>
+                            <div class="mga-option-toggle">
+                                <label for="mga_allow_body_fallback">
+                                    <input name="mga_settings[allowBodyFallback]" type="checkbox" id="mga_allow_body_fallback" value="1" <?php checked( ! empty( $settings['allowBodyFallback'] ), 1 ); ?> />
+                                    <span><?php echo esc_html__( 'Autoriser le repli sur &lt;body&gt;', 'lightbox-jlg' ); ?></span>
+                                </label>
+                                <p class="description"><?php echo esc_html__( "Active un repli sur l'élément &lt;body&gt; si le thème ne propose pas de zone de contenu compatible.", 'lightbox-jlg' ); ?></p>
+                            </div>
+                            <div class="mga-toolbar-options" role="group" aria-label="<?php echo esc_attr__( 'Commandes de la barre d’outils', 'lightbox-jlg' ); ?>">
+                                <div class="mga-option-toggle">
+                                    <input type="hidden" name="mga_settings[show_zoom]" value="0" />
+                                    <label for="mga_show_zoom">
+                                        <input name="mga_settings[show_zoom]" type="checkbox" id="mga_show_zoom" value="1" <?php checked( ! empty( $settings['show_zoom'] ), 1 ); ?> />
+                                        <span><?php echo esc_html__( 'Afficher le bouton de zoom', 'lightbox-jlg' ); ?></span>
+                                    </label>
+                                    <p class="description"><?php echo esc_html__( "Permet aux visiteurs de zoomer sur l'image affichée.", 'lightbox-jlg' ); ?></p>
+                                </div>
+                                <div class="mga-option-toggle">
+                                    <input type="hidden" name="mga_settings[show_download]" value="0" />
+                                    <label for="mga_show_download">
+                                        <input name="mga_settings[show_download]" type="checkbox" id="mga_show_download" value="1" <?php checked( ! empty( $settings['show_download'] ), 1 ); ?> />
+                                        <span><?php echo esc_html__( 'Afficher le bouton de téléchargement', 'lightbox-jlg' ); ?></span>
+                                    </label>
+                                    <p class="description"><?php echo esc_html__( "Autorise le téléchargement direct de l'image en cours.", 'lightbox-jlg' ); ?></p>
+                                </div>
+                                <div class="mga-option-toggle">
+                                    <input type="hidden" name="mga_settings[show_share]" value="0" />
+                                    <label for="mga_show_share">
+                                        <input name="mga_settings[show_share]" type="checkbox" id="mga_show_share" value="1" <?php checked( ! empty( $settings['show_share'] ), 1 ); ?> />
+                                        <span><?php echo esc_html__( 'Afficher le bouton de partage', 'lightbox-jlg' ); ?></span>
+                                    </label>
+                                    <p class="description"><?php echo esc_html__( "Affiche le bouton de partage via le navigateur ou un nouvel onglet.", 'lightbox-jlg' ); ?></p>
+                                </div>
+                                <div class="mga-option-toggle">
+                                    <input type="hidden" name="mga_settings[show_fullscreen]" value="0" />
+                                    <label for="mga_show_fullscreen">
+                                        <input name="mga_settings[show_fullscreen]" type="checkbox" id="mga_show_fullscreen" value="1" <?php checked( ! empty( $settings['show_fullscreen'] ), 1 ); ?> />
+                                        <span><?php echo esc_html__( 'Afficher le bouton plein écran', 'lightbox-jlg' ); ?></span>
+                                    </label>
+                                    <p class="description"><?php echo esc_html__( "Permet d'activer le mode plein écran depuis la barre d'outils.", 'lightbox-jlg' ); ?></p>
+                                </div>
+                            </div>
                         </fieldset>
                     </td>
                 </tr>

--- a/tests/phpunit/SettingsSanitizeTest.php
+++ b/tests/phpunit/SettingsSanitizeTest.php
@@ -102,6 +102,29 @@ class SettingsSanitizeTest extends WP_UnitTestCase {
                     'show_fullscreen' => $defaults['show_fullscreen'],
                 ],
             ],
+            'boolean_string_values' => [
+                [
+                    'loop'              => 'false',
+                    'autoplay_start'    => 'yes',
+                    'debug_mode'        => 'off',
+                    'allowBodyFallback' => 'false',
+                    'show_zoom'         => 'true',
+                    'show_download'     => 'no',
+                    'show_share'        => 'off',
+                    'show_fullscreen'   => 'on',
+                ],
+                [],
+                [
+                    'loop'              => false,
+                    'autoplay_start'    => true,
+                    'debug_mode'        => false,
+                    'allowBodyFallback' => false,
+                    'show_zoom'         => true,
+                    'show_download'     => false,
+                    'show_share'        => false,
+                    'show_fullscreen'   => true,
+                ],
+            ],
             'bogus_post_types_fall_back_to_defaults' => [
                 [
                     'tracked_post_types' => [ 'not-real', 'also_bad' ],


### PR DESCRIPTION
## Summary
- improve boolean sanitization for loop, autoplay, fallback, and toolbar toggles so settings respect explicit off values
- refresh the admin options layout with dedicated toolbar toggle checkboxes and supporting styles
- gate gallery toolbar buttons and listeners on settings, adjust spacing, and cover boolean string cases in tests

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68de6d55c524832e8ef8439f8fb5d354