### PR TITLE
Refine fallback sprintf helpers

### DIFF
--- a/ma-galerie-automatique/assets/js/admin-script.js
+++ b/ma-galerie-automatique/assets/js/admin-script.js
@@ -2,38 +2,41 @@
 (function(global) {
     const mgaAdminI18n = global.wp && global.wp.i18n ? global.wp.i18n : null;
     const mgaAdmin__ = mgaAdminI18n && typeof mgaAdminI18n.__ === 'function' ? mgaAdminI18n.__ : ( text ) => text;
+    const fallbackSprintf = ( format, ...args ) => {
+        let autoIndex = 0;
+
+        return format.replace(/%(\d+\$)?([sd])/g, (match, position, type) => {
+            let argIndex;
+
+            if (position) {
+                argIndex = parseInt(position, 10) - 1;
+            } else {
+                argIndex = autoIndex;
+                autoIndex += 1;
+            }
+
+            if (argIndex < 0 || argIndex >= args.length) {
+                return '';
+            }
+
+            const value = args[argIndex];
+
+            if (typeof value === 'undefined') {
+                return '';
+            }
+
+            if (type === 'd') {
+                const coerced = parseInt(value, 10);
+                return Number.isNaN(coerced) ? '' : String(coerced);
+            }
+
+            return String(value);
+        });
+    };
+
     const mgaAdminSprintf = mgaAdminI18n && typeof mgaAdminI18n.sprintf === 'function'
         ? mgaAdminI18n.sprintf
-        : ( format, ...args ) => {
-            let autoIndex = 0;
-            return format.replace(/%(\d+\$)?([sd])/g, (match, position, type) => {
-                let argIndex;
-
-                if (position) {
-                    argIndex = parseInt(position, 10) - 1;
-                } else {
-                    argIndex = autoIndex;
-                    autoIndex += 1;
-                }
-
-                if (argIndex < 0 || argIndex >= args.length) {
-                    return '';
-                }
-
-                const value = args[argIndex];
-
-                if (typeof value === 'undefined') {
-                    return '';
-                }
-
-                if (type === 'd') {
-                    const coerced = parseInt(value, 10);
-                    return Number.isNaN(coerced) ? '' : String(coerced);
-                }
-
-                return String(value);
-            });
-        };
+        : fallbackSprintf;
 
     const resolveFocusUtils = () => {
         if (global.mgaFocusUtils && typeof global.mgaFocusUtils === 'object') {

--- a/ma-galerie-automatique/assets/js/debug.js
+++ b/ma-galerie-automatique/assets/js/debug.js
@@ -3,38 +3,41 @@
 
     const mgaI18n = global.wp && global.wp.i18n ? global.wp.i18n : null;
     const mga__ = mgaI18n && typeof mgaI18n.__ === 'function' ? mgaI18n.__ : ( text ) => text;
+    const fallbackSprintf = ( format, ...args ) => {
+        let autoIndex = 0;
+
+        return format.replace(/%(\d+\$)?([sd])/g, (match, position, type) => {
+            let argIndex;
+
+            if (position) {
+                argIndex = parseInt(position, 10) - 1;
+            } else {
+                argIndex = autoIndex;
+                autoIndex += 1;
+            }
+
+            if (argIndex < 0 || argIndex >= args.length) {
+                return '';
+            }
+
+            const value = args[argIndex];
+
+            if (typeof value === 'undefined') {
+                return '';
+            }
+
+            if (type === 'd') {
+                const coerced = parseInt(value, 10);
+                return Number.isNaN(coerced) ? '' : String(coerced);
+            }
+
+            return String(value);
+        });
+    };
+
     const mgaSprintf = mgaI18n && typeof mgaI18n.sprintf === 'function'
         ? mgaI18n.sprintf
-        : ( format, ...args ) => {
-            let autoIndex = 0;
-            return format.replace(/%(\d+\$)?([sd])/g, (match, position, type) => {
-                let argIndex;
-
-                if (position) {
-                    argIndex = parseInt(position, 10) - 1;
-                } else {
-                    argIndex = autoIndex;
-                    autoIndex += 1;
-                }
-
-                if (argIndex < 0 || argIndex >= args.length) {
-                    return '';
-                }
-
-                const value = args[argIndex];
-
-                if (typeof value === 'undefined') {
-                    return '';
-                }
-
-                if (type === 'd') {
-                    const coerced = parseInt(value, 10);
-                    return Number.isNaN(coerced) ? '' : String(coerced);
-                }
-
-                return String(value);
-            });
-        };
+        : fallbackSprintf;
 
     const state = {
         panel: null,

--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -3,38 +3,41 @@
 
     const mgaI18n = window.wp && window.wp.i18n ? window.wp.i18n : null;
     const mga__ = mgaI18n && typeof mgaI18n.__ === 'function' ? mgaI18n.__ : ( text ) => text;
+    const fallbackSprintf = ( format, ...args ) => {
+        let autoIndex = 0;
+
+        return format.replace(/%(\d+\$)?([sd])/g, (match, position, type) => {
+            let argIndex;
+
+            if (position) {
+                argIndex = parseInt(position, 10) - 1;
+            } else {
+                argIndex = autoIndex;
+                autoIndex += 1;
+            }
+
+            if (argIndex < 0 || argIndex >= args.length) {
+                return '';
+            }
+
+            const value = args[argIndex];
+
+            if (typeof value === 'undefined') {
+                return '';
+            }
+
+            if (type === 'd') {
+                const coerced = parseInt(value, 10);
+                return Number.isNaN(coerced) ? '' : String(coerced);
+            }
+
+            return String(value);
+        });
+    };
+
     const mgaSprintf = mgaI18n && typeof mgaI18n.sprintf === 'function'
         ? mgaI18n.sprintf
-        : ( format, ...args ) => {
-            let autoIndex = 0;
-            return format.replace(/%(\d+\$)?([sd])/g, (match, position, type) => {
-                let argIndex;
-
-                if (position) {
-                    argIndex = parseInt(position, 10) - 1;
-                } else {
-                    argIndex = autoIndex;
-                    autoIndex += 1;
-                }
-
-                if (argIndex < 0 || argIndex >= args.length) {
-                    return '';
-                }
-
-                const value = args[argIndex];
-
-                if (typeof value === 'undefined') {
-                    return '';
-                }
-
-                if (type === 'd') {
-                    const coerced = parseInt(value, 10);
-                    return Number.isNaN(coerced) ? '' : String(coerced);
-                }
-
-                return String(value);
-            });
-        };
+        : fallbackSprintf;
 
     function updateEchoBackground(viewer, imageUrl) {
         if (!viewer) {


### PR DESCRIPTION
## Summary
- extract a shared fallback sprintf helper in the admin, debug, and gallery scripts to support numbered %s/%d placeholders
- ensure all fallbacks coerce integer placeholders and return empty strings for missing arguments

## Testing
- node <<'NODE' ... NODE

------
https://chatgpt.com/codex/tasks/task_e_68de8499f52c832eb0ab17bc3451f282