### PR TITLE
Improve fallback sprintf token handling when wp.i18n is missing

### DIFF
--- a/ma-galerie-automatique/assets/js/admin-script.js
+++ b/ma-galerie-automatique/assets/js/admin-script.js
@@ -2,14 +2,21 @@
 (function(global) {
     const mgaAdminI18n = global.wp && global.wp.i18n ? global.wp.i18n : null;
     const mgaAdmin__ = mgaAdminI18n && typeof mgaAdminI18n.__ === 'function' ? mgaAdminI18n.__ : ( text ) => text;
+    const TOKEN_REGEX = /%(\d+\$)?([sd])/g;
     const fallbackSprintf = ( format, ...args ) => {
         let autoIndex = 0;
 
-        return format.replace(/%(\d+\$)?([sd])/g, (match, position, type) => {
+        return String(format).replace(TOKEN_REGEX, (match, position, type) => {
             let argIndex;
 
             if (position) {
-                argIndex = parseInt(position, 10) - 1;
+                const numericIndex = parseInt(position.slice(0, -1), 10);
+
+                if (Number.isNaN(numericIndex) || numericIndex <= 0) {
+                    return '';
+                }
+
+                argIndex = numericIndex - 1;
             } else {
                 argIndex = autoIndex;
                 autoIndex += 1;

--- a/ma-galerie-automatique/assets/js/debug.js
+++ b/ma-galerie-automatique/assets/js/debug.js
@@ -3,14 +3,21 @@
 
     const mgaI18n = global.wp && global.wp.i18n ? global.wp.i18n : null;
     const mga__ = mgaI18n && typeof mgaI18n.__ === 'function' ? mgaI18n.__ : ( text ) => text;
+    const TOKEN_REGEX = /%(\d+\$)?([sd])/g;
     const fallbackSprintf = ( format, ...args ) => {
         let autoIndex = 0;
 
-        return format.replace(/%(\d+\$)?([sd])/g, (match, position, type) => {
+        return String(format).replace(TOKEN_REGEX, (match, position, type) => {
             let argIndex;
 
             if (position) {
-                argIndex = parseInt(position, 10) - 1;
+                const numericIndex = parseInt(position.slice(0, -1), 10);
+
+                if (Number.isNaN(numericIndex) || numericIndex <= 0) {
+                    return '';
+                }
+
+                argIndex = numericIndex - 1;
             } else {
                 argIndex = autoIndex;
                 autoIndex += 1;

--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -3,14 +3,21 @@
 
     const mgaI18n = window.wp && window.wp.i18n ? window.wp.i18n : null;
     const mga__ = mgaI18n && typeof mgaI18n.__ === 'function' ? mgaI18n.__ : ( text ) => text;
+    const TOKEN_REGEX = /%(\d+\$)?([sd])/g;
     const fallbackSprintf = ( format, ...args ) => {
         let autoIndex = 0;
 
-        return format.replace(/%(\d+\$)?([sd])/g, (match, position, type) => {
+        return String(format).replace(TOKEN_REGEX, (match, position, type) => {
             let argIndex;
 
             if (position) {
-                argIndex = parseInt(position, 10) - 1;
+                const numericIndex = parseInt(position.slice(0, -1), 10);
+
+                if (Number.isNaN(numericIndex) || numericIndex <= 0) {
+                    return '';
+                }
+
+                argIndex = numericIndex - 1;
             } else {
                 argIndex = autoIndex;
                 autoIndex += 1;


### PR DESCRIPTION
## Summary
- update the fallback sprintf helper in the admin, debug, and gallery scripts to share a single token matcher
- ensure numbered placeholders map to the right argument, coercing %d values to integers and returning empty strings when data is missing

## Testing
- node - <<'NODE'
const fs = require('fs');
const vm = require('vm');
const path = 'ma-galerie-automatique/assets/js/gallery-slideshow.js';
const code = fs.readFileSync(path, 'utf8');
const match = code.match(/const fallbackSprintf = \( format, \.\.\.args \) => {([\s\S]*?)    };/);
if (!match) throw new Error('fallbackSprintf not found');
const script = `const TOKEN_REGEX = /%(\\d+\\$)?([sd])/g;\n${match[0]}\nfallbackSprintf;`;
const sandbox = { window: { wp: {} } };
const fallback = vm.runInNewContext(script, sandbox);
const outputs = [
  fallback('openViewer appelé avec %1$d images, index %2$d.', 5, 2),
  fallback('MGA [%1$ss] : %2$s', '12.345', 'Fin prête'),
  fallback('Missing: %1$s %2$s', 'only-one'),
  fallback('Sequence %s then %1$s and %d plus %2$d', 'alpha', 'beta', 42, 7.8),
];
console.log(outputs.join('\n'));
NODE

------
https://chatgpt.com/codex/tasks/task_e_68de8b8e5068832e91e86fb4434eb5d0