### PR TITLE
Add Gutenberg preview block and modernize editor integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ La visionneuse plein écran pilotée par `assets/js/gallery-slideshow.js` et mis
 - **Compatibilité avec les pièces jointes WordPress** : les galeries configurées avec `linkDestination: "attachment"` ouvrent la visionneuse sur le média original en s’appuyant sur les attributs `data-full-url` / `data-orig-file` des images.
 
 ### Prévisualisation dans l’éditeur de blocs
-- **Enfilement dédié** : le hook `enqueue_block_editor_assets` charge `assets/js/block-editor-preview.js` et `assets/css/block-editor-preview.css` uniquement dans Gutenberg pour éviter l’exécution de la lightbox complète côté administration.
-- **Mise en évidence immédiate** : les images liées détectées dans les blocs `core/gallery`, `core/image` et `core/media-text` sont entourées d’un halo reprenant la couleur d’accent définie dans les réglages et une pastille « Lightbox active » apparaît dans le coin du bloc.
-- **Blocs réutilisables pris en charge** : lorsqu’un bloc réutilisable (`core/block`) contient un bloc supporté, la pastille s’affiche également sur le conteneur afin de signaler que la lightbox restera active une fois publiée.
-- **Anti-cliques accidentels** : les liens d’aperçu sont neutralisés (clic ou touche Entrée) pour éviter toute navigation hors de l’éditeur tout en offrant un rendu proche du frontal.
+- **Bloc « Lightbox – Aperçu »** : un bloc dédié (`assets/js/block/index.js`) simule la visionneuse dans Gutenberg. L’inspector expose les options clés (lecture auto, contrôles, styles) et l’aperçu réduit réutilise les classes CSS de la lightbox pour refléter fidèlement le rendu.
+- **Chargement ciblé** : le hook `enqueue_block_editor_assets` enfile désormais `assets/js/block-editor-preview.js`, `assets/css/block-editor-preview.css` et la feuille `assets/css/block/editor.css` uniquement côté éditeur.
+- **Décorations natives** : le script `block-editor-preview.js` s’appuie sur l’API `editor.BlockListBlock` pour ajouter la pastille « Lightbox active » aux blocs `core/gallery`, `core/image`, `core/media-text` et `core/cover` lorsqu’une image est liée à son fichier média. Plus besoin de MutationObserver ni de modifications directes du DOM.
+- **Compatibilité réutilisable** : les blocs réutilisables héritent automatiquement du marquage grâce à l’analyse des attributs Gutenberg, garantissant une indication cohérente quel que soit le contexte d’utilisation.
 
 ### Mode débogage
 - **Activation** : cochez **Activer le mode débogage** dans les réglages du plugin (onglet **Réglages → Ma Galerie Automatique**), case ajoutée par `includes/admin-page-template.php`.

--- a/ma-galerie-automatique/assets/css/block/editor.css
+++ b/ma-galerie-automatique/assets/css/block/editor.css
@@ -1,0 +1,227 @@
+.mga-block-preview {
+    position: relative;
+    padding: 16px;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    border-radius: 12px;
+    background: #fff;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.mga-block-preview__container {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.mga-block-preview__viewer {
+    position: relative;
+    width: 100%;
+    max-width: 520px;
+    margin: 0 auto;
+    padding: 18px 18px 12px;
+    border-radius: 18px;
+    background: rgba(10, 10, 10, var(--mga-bg-opacity, 0.95));
+    box-shadow: 0 15px 35px rgba(10, 10, 10, 0.25);
+    overflow: hidden;
+}
+
+.mga-block-preview__viewer .mga-header {
+    position: relative;
+    top: auto;
+    left: auto;
+    width: 100%;
+    padding: 0 0 12px;
+    background: none;
+}
+
+.mga-block-preview__viewer .mga-counter {
+    font-weight: 600;
+    color: #fff;
+}
+
+.mga-block-preview__viewer .mga-toolbar {
+    display: flex;
+    gap: 6px;
+}
+
+.mga-block-preview__viewer .mga-toolbar-button {
+    border: none;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 999px;
+    padding: 6px 12px;
+    font-size: 14px;
+    color: var(--mga-accent-color, #fff);
+    line-height: 1;
+}
+
+.mga-block-preview__viewer .mga-toolbar-button[disabled] {
+    cursor: default;
+    opacity: 0.85;
+}
+
+.mga-block-preview__viewer .mga-toolbar-button .mga-icon {
+    font-size: 16px;
+}
+
+.mga-block-preview__viewer .mga-main-swiper {
+    width: 100%;
+    height: auto;
+    min-height: 220px;
+    border-radius: 14px;
+    overflow: hidden;
+    background: rgba(0, 0, 0, 0.6);
+}
+
+.mga-block-preview__viewer .swiper-wrapper {
+    display: flex;
+    gap: 0;
+}
+
+.mga-block-preview__viewer .swiper-slide {
+    flex: 1 0 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 12px;
+}
+
+.mga-block-preview__viewer .swiper-slide img {
+    width: 100%;
+    height: auto;
+    border-radius: 12px;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.25);
+}
+
+.mga-block-preview__viewer .swiper-button-prev,
+.mga-block-preview__viewer .swiper-button-next {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    background: rgba(15, 23, 42, 0.65);
+    color: var(--mga-accent-color, #fff);
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    font-size: 18px;
+    pointer-events: none;
+}
+
+.mga-block-preview__viewer .swiper-button-prev {
+    left: 24px;
+}
+
+.mga-block-preview__viewer .swiper-button-next {
+    right: 24px;
+}
+
+.mga-block-preview__viewer .mga-caption-container {
+    padding: 16px 10px 0;
+}
+
+.mga-block-preview__viewer .mga-caption {
+    margin: 0;
+    color: #fff;
+    font-style: italic;
+    font-size: 15px;
+    text-align: center;
+}
+
+.mga-block-preview__viewer .mga-thumbs-swiper {
+    width: 100%;
+    margin-top: 12px;
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+}
+
+.mga-block-preview__viewer .mga-thumbs-swiper .swiper-wrapper {
+    display: flex;
+    gap: 8px;
+}
+
+.mga-block-preview__viewer .mga-thumbs-swiper .swiper-slide {
+    width: 72px;
+    height: 48px;
+    opacity: 0.55;
+    border-radius: 8px;
+    overflow: hidden;
+    border: 2px solid transparent;
+}
+
+.mga-block-preview__viewer .mga-thumbs-swiper .swiper-slide-thumb-active {
+    opacity: 1;
+    border-color: var(--mga-accent-color, #fff);
+}
+
+.mga-block-preview__viewer .mga-thumb-button {
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    background: none;
+    border: none;
+}
+
+.mga-block-preview__viewer .mga-thumb-button img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.mga-block-preview__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: center;
+}
+
+.mga-block-preview__chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: rgba(49, 72, 165, 0.1);
+    color: #3148a5;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+}
+
+.mga-block-preview[data-mga-lightbox-note]::after {
+    content: attr(data-mga-lightbox-note);
+    position: absolute;
+    top: -10px;
+    right: 16px;
+    padding: 4px 12px;
+    background: rgba(10, 10, 10, 0.8);
+    color: #fff;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.mga-block-preview .mga-screen-reader-text {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+}
+
+@media (max-width: 782px) {
+    .mga-block-preview__viewer {
+        padding: 16px 14px 10px;
+    }
+
+    .mga-block-preview__viewer .swiper-button-prev,
+    .mga-block-preview__viewer .swiper-button-next {
+        display: none;
+    }
+}

--- a/ma-galerie-automatique/assets/js/block-editor-preview.js
+++ b/ma-galerie-automatique/assets/js/block-editor-preview.js
@@ -1,271 +1,166 @@
-(function() {
+( function() {
     'use strict';
 
-    const root = window || {};
-    const wp = root.wp || {};
-    const i18n = wp.i18n || {};
-    const dataStore = wp.data || null;
-    const domReady = typeof wp.domReady === 'function'
-        ? wp.domReady
-        : function(callback) {
-            if (document.readyState === 'loading') {
-                document.addEventListener('DOMContentLoaded', callback);
-            } else {
-                callback();
-            }
-        };
+    var root = window || {};
+    var wp = root.wp || {};
 
-    const __ = typeof i18n.__ === 'function' ? i18n.__ : function(text) { return text; };
-
-    const editorSettings = root.mgaBlockEditorPreview || {};
-    const defaultNote = __('Lightbox active', 'lightbox-jlg');
-    const noteText = typeof editorSettings.noteText === 'string' && editorSettings.noteText.trim()
-        ? editorSettings.noteText.trim()
-        : defaultNote;
-    const reusableSuffix = __('Reusable block', 'lightbox-jlg');
-    const reusableNote = noteText + ' · ' + reusableSuffix;
-
-    const supportedBlocks = Array.isArray(editorSettings.supportedBlocks)
-        ? editorSettings.supportedBlocks.filter(function(name) {
-            return typeof name === 'string' && name.trim().length > 0;
-        })
-        : [];
-    const supportedSet = supportedBlocks.length ? new Set(supportedBlocks) : null;
-
-    const canvasSelector = '.block-editor-block-list__layout';
-    const blockSelector = '.block-editor-block-list__block[data-type]';
-    const linkClass = 'mga-editor-preview__link';
-    const imageClass = 'mga-editor-preview__image';
-    const activeClass = 'mga-editor-preview--lightbox';
-    const noteAttr = 'data-mga-lightbox-note';
-    const IMAGE_PATTERN = /\.(?:jpe?g|png|gif|bmp|webp|avif|svg)(?:\?.*)?(?:#.*)?$/i;
-
-    const raf = typeof root.requestAnimationFrame === 'function'
-        ? root.requestAnimationFrame.bind(root)
-        : function(callback) { return setTimeout(callback, 16); };
-
-    let rafId = null;
-    let mutationObserver = null;
-    const observerConfig = {
-        childList: true,
-        subtree: true,
-        attributes: true,
-        attributeFilter: [ 'href', 'class', 'data-type' ],
-    };
-
-    function scheduleUpdate() {
-        if (rafId) {
-            return;
-        }
-
-        rafId = raf(function() {
-            rafId = null;
-            updateHighlights();
-        });
+    if ( ! wp.hooks || ! wp.compose || ! wp.element || ! wp.blockEditor ) {
+        return;
     }
 
-    function isSupportedBlockName(blockName) {
-        if (!blockName) {
+    var hooks = wp.hooks;
+    var compose = wp.compose;
+    var element = wp.element;
+    var blockEditor = wp.blockEditor || wp.editor;
+    var data = wp.data || {};
+    var i18n = wp.i18n || {};
+    var __ = typeof i18n.__ === 'function' ? i18n.__ : function( text ) { return text; };
+
+    var BlockListBlock = blockEditor && blockEditor.BlockListBlock ? blockEditor.BlockListBlock : null;
+
+    if ( ! BlockListBlock || typeof hooks.addFilter !== 'function' || typeof compose.createHigherOrderComponent !== 'function' ) {
+        return;
+    }
+
+    var createElement = element.createElement;
+    var Fragment = element.Fragment || function Fragment( props ) {
+        return props.children || null;
+    };
+
+    var previewSettings = root.mgaBlockEditorPreview || {};
+    var noteText = typeof previewSettings.noteText === 'string' && previewSettings.noteText.trim()
+        ? previewSettings.noteText
+        : __( 'Lightbox active', 'lightbox-jlg' );
+
+    var supportedBlocks = Array.isArray( previewSettings.supportedBlocks ) ? previewSettings.supportedBlocks : [];
+    var previewBlockName = typeof previewSettings.previewBlockName === 'string' && previewSettings.previewBlockName
+        ? previewSettings.previewBlockName
+        : 'ma-galerie-automatique/lightbox-preview';
+
+    var supportSet = ( function() {
+        var list = supportedBlocks.slice();
+        if ( list.indexOf( previewBlockName ) === -1 ) {
+            list.push( previewBlockName );
+        }
+        var unique = {};
+        for ( var i = 0; i < list.length; i++ ) {
+            var key = String( list[ i ] || '' );
+            if ( key ) {
+                unique[ key ] = true;
+            }
+        }
+        return unique;
+    } )();
+
+    function classnames() {
+        var buffer = [];
+        for ( var i = 0; i < arguments.length; i++ ) {
+            var value = arguments[ i ];
+            if ( ! value ) {
+                continue;
+            }
+            if ( typeof value === 'string' ) {
+                buffer.push( value );
+            } else if ( Array.isArray( value ) ) {
+                buffer = buffer.concat( value );
+            }
+        }
+        return buffer.join( ' ' ).trim();
+    }
+
+    function blockIsSupported( block ) {
+        if ( ! block || ! block.name ) {
             return false;
         }
 
-        if (!supportedSet) {
+        return !! supportSet[ block.name ];
+    }
+
+    function galleryHasLinkedImages( block ) {
+        var attributes = block.attributes || {};
+
+        if ( 'core/gallery' === block.name ) {
+            if ( attributes.linkTo && 'none' !== attributes.linkTo ) {
+                return true;
+            }
+
+            if ( Array.isArray( attributes.images ) ) {
+                for ( var i = 0; i < attributes.images.length; i++ ) {
+                    var image = attributes.images[ i ];
+                    if ( image && ( image.url || image.link ) ) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        if ( 'core/image' === block.name ) {
+            if ( attributes.href && attributes.href.length ) {
+                return true;
+            }
+
+            if ( attributes.linkDestination && 'none' !== attributes.linkDestination ) {
+                return true;
+            }
+
+            return false;
+        }
+
+        if ( 'core/media-text' === block.name ) {
+            return !! ( attributes.mediaLink && attributes.mediaLink.length );
+        }
+
+        if ( 'core/cover' === block.name ) {
+            return !! ( attributes.url || attributes.mediaId );
+        }
+
+        if ( 'ma-galerie-automatique/lightbox-preview' === block.name ) {
             return true;
         }
 
-        return supportedSet.has(blockName);
+        return false;
     }
 
-    function markReusableBlocks(canvas) {
-        if (!canvas) {
-            return;
-        }
-
-        const reusableBlocks = canvas.querySelectorAll(blockSelector + '[data-type="core/block"]');
-        reusableBlocks.forEach(function(reusable) {
-            const childActive = reusable.querySelector(blockSelector + '.' + activeClass + ':not([data-type="core/block"])');
-
-            if (childActive) {
-                reusable.classList.add(activeClass);
-                reusable.setAttribute(noteAttr, reusableNote);
-            } else {
-                reusable.classList.remove(activeClass);
-                reusable.removeAttribute(noteAttr);
-            }
-        });
-    }
-
-    function cleanupCanvas(canvas) {
-        if (!canvas) {
-            return;
-        }
-
-        canvas.querySelectorAll('.' + imageClass).forEach(function(image) {
-            image.classList.remove(imageClass);
-        });
-
-        canvas.querySelectorAll('.' + linkClass).forEach(function(link) {
-            link.classList.remove(linkClass);
-        });
-
-        canvas.querySelectorAll(blockSelector + '.' + activeClass).forEach(function(block) {
-            block.classList.remove(activeClass);
-            block.removeAttribute(noteAttr);
-        });
-    }
-
-    function updateHighlights() {
-        const canvas = document.querySelector(canvasSelector);
-
-        if (!canvas) {
-            return;
-        }
-
-        if (mutationObserver) {
-            mutationObserver.disconnect();
-        }
-
-        cleanupCanvas(canvas);
-
-        const blocks = canvas.querySelectorAll(blockSelector);
-
-        blocks.forEach(function(block) {
-            const blockName = block.getAttribute('data-type') || '';
-
-            if (!isSupportedBlockName(blockName)) {
-                return;
-            }
-
-            let hasEligibleLink = false;
-
-            block.querySelectorAll('a[href]').forEach(function(anchor) {
-                if (!(anchor instanceof Element)) {
-                    return;
-                }
-
-                const href = anchor.getAttribute('href');
-
-                if (!href || !IMAGE_PATTERN.test(href)) {
-                    return;
-                }
-
-                const linkedImage = anchor.querySelector('img');
-
-                if (!linkedImage) {
-                    return;
-                }
-
-                if (anchor.closest('[data-mga-lightbox-ignore="true"]')) {
-                    return;
-                }
-
-                anchor.classList.add(linkClass);
-                linkedImage.classList.add(imageClass);
-                hasEligibleLink = true;
-            });
-
-            if (hasEligibleLink) {
-                block.classList.add(activeClass);
-                block.setAttribute(noteAttr, noteText);
-            }
-        });
-
-        markReusableBlocks(canvas);
-
-        if (mutationObserver) {
-            mutationObserver.observe(canvas, observerConfig);
-        }
-    }
-
-    function preventNavigation(event) {
-        const target = event.target;
-
-        if (!(target instanceof Element)) {
-            return;
-        }
-
-        const anchor = target.closest('a.' + linkClass);
-
-        if (!anchor) {
-            return;
-        }
-
-        if (!anchor.closest(canvasSelector)) {
-            return;
-        }
-
-        event.preventDefault();
-        event.stopPropagation();
-    }
-
-    function preventKeyboardNavigation(event) {
-        if ('Enter' !== event.key) {
-            return;
-        }
-
-        const target = event.target;
-
-        if (!(target instanceof Element)) {
-            return;
-        }
-
-        const anchor = target.closest('a.' + linkClass);
-
-        if (!anchor) {
-            return;
-        }
-
-        if (!anchor.closest(canvasSelector)) {
-            return;
-        }
-
-        event.preventDefault();
-        event.stopPropagation();
-    }
-
-    function observeCanvas(canvas) {
-        if (!('MutationObserver' in root) || !canvas) {
-            return;
-        }
-
-        if (!mutationObserver) {
-            mutationObserver = new MutationObserver(scheduleUpdate);
-        } else {
-            mutationObserver.disconnect();
-        }
-
-        mutationObserver.observe(canvas, observerConfig);
-    }
-
-    function bootstrap() {
-        const canvas = document.querySelector(canvasSelector);
-
-        if (!canvas) {
+    function shouldDecorateBlock( block ) {
+        if ( ! blockIsSupported( block ) ) {
             return false;
         }
 
-        observeCanvas(canvas);
-        updateHighlights();
-
-        return true;
+        return galleryHasLinkedImages( block );
     }
 
-    domReady(function() {
-        if (!bootstrap()) {
-            (function waitForCanvas() {
-                if (bootstrap()) {
-                    return;
-                }
+    var withLightboxPreview = compose.createHigherOrderComponent( function( OriginalComponent ) {
+        return function( props ) {
+            if ( ! props || ! shouldDecorateBlock( props.block ) ) {
+                return createElement( OriginalComponent, props );
+            }
 
-                raf(waitForCanvas);
-            })();
+            var extraClass = 'mga-editor-preview--lightbox';
+            var mergedClassName = classnames( props.className, extraClass );
+            var wrapperProps = props.wrapperProps ? Object.assign( {}, props.wrapperProps ) : {};
+            wrapperProps.className = classnames( wrapperProps.className, extraClass );
+            wrapperProps[ 'data-mga-lightbox-note' ] = noteText;
+
+            var enhancedProps = Object.assign( {}, props, {
+                className: mergedClassName,
+                wrapperProps: wrapperProps
+            } );
+
+            return createElement( Fragment, null, createElement( OriginalComponent, enhancedProps ) );
+        };
+    }, 'withMgaLightboxPreview' );
+
+    hooks.addFilter( 'editor.BlockListBlock', 'ma-galerie-automatique/lightbox-preview', withLightboxPreview );
+
+    if ( data && typeof data.dispatch === 'function' && previewBlockName ) {
+        try {
+            data.dispatch( 'core/block-editor' ).updateSettings( {
+                __experimentalPreferredStyleVariations: data.select( 'core/block-editor' ).getSettings().__experimentalPreferredStyleVariations,
+            } );
+        } catch ( error ) {
+            // Silencieux : certaines versions de WordPress n’exposent pas updateSettings.
         }
-
-        document.addEventListener('click', preventNavigation, true);
-        document.addEventListener('keydown', preventKeyboardNavigation, true);
-
-        if (dataStore && typeof dataStore.subscribe === 'function') {
-            dataStore.subscribe(scheduleUpdate);
-        }
-    });
-})();
+    }
+} )();

--- a/ma-galerie-automatique/assets/js/block/index.js
+++ b/ma-galerie-automatique/assets/js/block/index.js
@@ -1,0 +1,432 @@
+/* global mgaBlockDefaults */
+( function() {
+    'use strict';
+
+    var root = window || {};
+    var wp = root.wp || {};
+
+    if ( ! wp.blocks || ! wp.element || ! wp.components ) {
+        return;
+    }
+
+    var registerBlockType = wp.blocks.registerBlockType;
+
+    if ( ! registerBlockType ) {
+        return;
+    }
+
+    var i18n = wp.i18n || {};
+    var __ = typeof i18n.__ === 'function' ? i18n.__ : function( text ) {
+        return text;
+    };
+
+    var element = wp.element;
+    var el = element.createElement;
+    var Fragment = element.Fragment || function Fragment( props ) {
+        return props.children || null;
+    };
+
+    var blockEditor = wp.blockEditor || wp.editor || {};
+    var InspectorControls = blockEditor.InspectorControls;
+    var useBlockProps = typeof blockEditor.useBlockProps === 'function'
+        ? blockEditor.useBlockProps
+        : function( extraProps ) {
+            return extraProps || {};
+        };
+
+    var components = wp.components || {};
+    var PanelBody = components.PanelBody;
+    var ToggleControl = components.ToggleControl;
+    var SelectControl = components.SelectControl;
+    var RangeControl = components.RangeControl;
+    var ColorPalette = components.ColorPalette;
+    var BaseControl = components.BaseControl;
+    var Notice = components.Notice;
+
+    var data = wp.data || {};
+    var useSelect = typeof data.useSelect === 'function' ? data.useSelect : null;
+
+    var defaults = root.mgaBlockDefaults || {};
+
+    function getDefault( key, fallback ) {
+        if ( Object.prototype.hasOwnProperty.call( defaults, key ) ) {
+            return defaults[ key ];
+        }
+
+        return fallback;
+    }
+
+    var defaultAccent = getDefault( 'accentColor', '#ffffff' );
+    var defaultBackgroundStyle = getDefault( 'backgroundStyle', 'echo' );
+    var defaultAutoplay = !! getDefault( 'autoplay', false );
+    var defaultLoop = !! getDefault( 'loop', true );
+    var defaultDelay = parseInt( getDefault( 'delay', 4 ), 10 ) || 4;
+    var defaultBgOpacity = parseFloat( getDefault( 'bgOpacity', 0.95 ) ) || 0.95;
+    var defaultThumbsMobile = !! getDefault( 'showThumbsMobile', true );
+    var defaultZoom = !! getDefault( 'showZoom', true );
+    var defaultDownload = !! getDefault( 'showDownload', true );
+    var defaultShare = !! getDefault( 'showShare', true );
+    var defaultFullscreen = !! getDefault( 'showFullscreen', true );
+    var noteText = getDefault( 'noteText', __( 'Lightbox active', 'lightbox-jlg' ) );
+
+    var PLACEHOLDER_IMAGES = [
+        { color: '#3148a5', label: __( 'Montagnes', 'lightbox-jlg' ) },
+        { color: '#c9356b', label: __( 'Portrait', 'lightbox-jlg' ) },
+        { color: '#f4a261', label: __( 'Architecture', 'lightbox-jlg' ) }
+    ];
+
+    function createPlaceholder( color, label ) {
+        var safeColor = color || '#888888';
+        var safeLabel = label || '';
+        var svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" role="img" aria-label="' + safeLabel.replace( /"/g, '&quot;' ) + '">' +
+            '<defs>' +
+                '<linearGradient id="grad" x1="0%" x2="100%" y1="0%" y2="100%">' +
+                    '<stop offset="0%" stop-color="' + safeColor + '" stop-opacity="0.95" />' +
+                    '<stop offset="100%" stop-color="#111" stop-opacity="0.85" />' +
+                '</linearGradient>' +
+            '</defs>' +
+            '<rect width="600" height="400" fill="url(#grad)" />' +
+            '<text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="48" fill="#fff" font-family="sans-serif" opacity="0.9">' + safeLabel.replace( /</g, '&lt;' ) + '</text>' +
+        '</svg>';
+
+        return 'data:image/svg+xml;utf8,' + encodeURIComponent( svg );
+    }
+
+    function getPaletteColors() {
+        if ( ! useSelect ) {
+            return [];
+        }
+
+        return useSelect( function( select ) {
+            var editorStore = select( 'core/block-editor' );
+
+            if ( ! editorStore || typeof editorStore.getSettings !== 'function' ) {
+                return [];
+            }
+
+            var settings = editorStore.getSettings();
+
+            if ( settings && settings.colors ) {
+                return settings.colors;
+            }
+
+            return [];
+        }, [] ) || [];
+    }
+
+    function renderToolbarButton( icon, label ) {
+        return el(
+            'button',
+            {
+                type: 'button',
+                className: 'mga-toolbar-button',
+                disabled: true,
+                'aria-disabled': 'true'
+            },
+            el( 'span', { className: 'mga-icon', 'aria-hidden': 'true' }, icon ),
+            el( 'span', { className: 'mga-screen-reader-text' }, label )
+        );
+    }
+
+    function Preview( props ) {
+        var attributes = props.attributes || {};
+        var accentColor = attributes.accentColor || defaultAccent;
+        var backgroundStyle = attributes.backgroundStyle || defaultBackgroundStyle;
+        var autoplay = typeof attributes.autoplay === 'boolean' ? attributes.autoplay : defaultAutoplay;
+        var loop = typeof attributes.loop === 'boolean' ? attributes.loop : defaultLoop;
+        var delay = attributes.delay || defaultDelay;
+        var bgOpacity = attributes.bgOpacity || defaultBgOpacity;
+        var showThumbsMobile = typeof attributes.showThumbsMobile === 'boolean' ? attributes.showThumbsMobile : defaultThumbsMobile;
+        var showZoom = typeof attributes.showZoom === 'boolean' ? attributes.showZoom : defaultZoom;
+        var showDownload = typeof attributes.showDownload === 'boolean' ? attributes.showDownload : defaultDownload;
+        var showShare = typeof attributes.showShare === 'boolean' ? attributes.showShare : defaultShare;
+        var showFullscreen = typeof attributes.showFullscreen === 'boolean' ? attributes.showFullscreen : defaultFullscreen;
+
+        var viewerClasses = [ 'mga-viewer', 'mga-block-preview__viewer' ];
+
+        if ( 'blur' === backgroundStyle ) {
+            viewerClasses.push( 'mga-has-blur' );
+        } else if ( 'texture' === backgroundStyle ) {
+            viewerClasses.push( 'mga-has-texture' );
+        }
+
+        if ( ! showThumbsMobile ) {
+            viewerClasses.push( 'mga-hide-thumbs-mobile' );
+        }
+
+        var viewerStyle = {
+            '--mga-accent-color': accentColor,
+            '--mga-bg-opacity': String( bgOpacity )
+        };
+
+        var slides = [];
+
+        for ( var i = 0; i < PLACEHOLDER_IMAGES.length; i++ ) {
+            var item = PLACEHOLDER_IMAGES[ i ];
+            slides.push( el(
+                'div',
+                {
+                    key: 'slide-' + i,
+                    className: 'swiper-slide' + ( i === 0 ? ' swiper-slide-active' : '' )
+                },
+                el( 'img', {
+                    src: createPlaceholder( item.color, item.label ),
+                    alt: item.label,
+                    loading: 'lazy'
+                } )
+            ) );
+        }
+
+        var thumbs = [];
+
+        for ( var j = 0; j < PLACEHOLDER_IMAGES.length; j++ ) {
+            var thumb = PLACEHOLDER_IMAGES[ j ];
+            thumbs.push( el(
+                'div',
+                {
+                    key: 'thumb-' + j,
+                    className: 'swiper-slide' + ( j === 0 ? ' swiper-slide-thumb-active' : '' )
+                },
+                el( 'button', { type: 'button', className: 'mga-thumb-button', disabled: true },
+                    el( 'img', {
+                        src: createPlaceholder( thumb.color, thumb.label ),
+                        alt: thumb.label,
+                        loading: 'lazy'
+                    } )
+                )
+            ) );
+        }
+
+        return el(
+            'div',
+            { className: 'mga-block-preview__container' },
+            el(
+                'div',
+                { className: viewerClasses.join( ' ' ), style: viewerStyle, 'aria-hidden': 'true' },
+                el(
+                    'div',
+                    { className: 'mga-header' },
+                    el( 'span', { className: 'mga-counter' }, '1 / ' + PLACEHOLDER_IMAGES.length ),
+                    el(
+                        'div',
+                        { className: 'mga-toolbar' },
+                        autoplay ? renderToolbarButton( '⏸', __( 'Mettre en pause', 'lightbox-jlg' ) ) : renderToolbarButton( '▶', __( 'Lire', 'lightbox-jlg' ) ),
+                        showZoom ? renderToolbarButton( '🔍', __( 'Zoomer', 'lightbox-jlg' ) ) : null,
+                        showDownload ? renderToolbarButton( '⬇', __( 'Télécharger', 'lightbox-jlg' ) ) : null,
+                        showShare ? renderToolbarButton( '⤴', __( 'Partager', 'lightbox-jlg' ) ) : null,
+                        showFullscreen ? renderToolbarButton( '⤢', __( 'Plein écran', 'lightbox-jlg' ) ) : null
+                    )
+                ),
+                el(
+                    'div',
+                    { className: 'mga-main-swiper' },
+                    el( 'div', { className: 'swiper-wrapper' }, slides ),
+                    el( 'div', { className: 'swiper-button-prev', 'aria-hidden': 'true' }, '‹' ),
+                    el( 'div', { className: 'swiper-button-next', 'aria-hidden': 'true' }, '›' )
+                ),
+                el(
+                    'div',
+                    { className: 'mga-caption-container' },
+                    el( 'p', { className: 'mga-caption' }, __( 'Aperçu de la visionneuse', 'lightbox-jlg' ) )
+                ),
+                el(
+                    'div',
+                    { className: 'mga-thumbs-swiper' },
+                    el( 'div', { className: 'swiper-wrapper' }, thumbs )
+                )
+            ),
+            el(
+                'div',
+                { className: 'mga-block-preview__meta' },
+                el( 'span', { className: 'mga-block-preview__chip' }, autoplay ? __( 'Lecture auto activée', 'lightbox-jlg' ) : __( 'Lecture manuelle', 'lightbox-jlg' ) ),
+                el( 'span', { className: 'mga-block-preview__chip' }, loop ? __( 'Boucle', 'lightbox-jlg' ) : __( 'Une seule lecture', 'lightbox-jlg' ) ),
+                el( 'span', { className: 'mga-block-preview__chip' }, __( 'Délai : ', 'lightbox-jlg' ) + delay + 's' )
+            )
+        );
+    }
+
+    function Edit( props ) {
+        var attributes = props.attributes || {};
+        var setAttributes = props.setAttributes || function() {};
+        var palette = getPaletteColors();
+
+        var blockProps = useBlockProps( {
+            className: 'mga-block-preview mga-editor-preview--lightbox'
+        } );
+
+        if ( blockProps.className ) {
+            blockProps.className += ' mga-block-preview--block';
+        } else {
+            blockProps.className = 'mga-block-preview mga-editor-preview--lightbox mga-block-preview--block';
+        }
+
+        blockProps[ 'data-mga-lightbox-note' ] = noteText;
+
+        function onToggle( key ) {
+            return function( value ) {
+                var newValue = typeof value === 'boolean' ? value : ! attributes[ key ];
+                var update = {};
+                update[ key ] = newValue;
+                setAttributes( update );
+            };
+        }
+
+        function onChangeAccent( color ) {
+            setAttributes( { accentColor: color || defaultAccent } );
+        }
+
+        return el(
+            Fragment,
+            null,
+            InspectorControls ? el(
+                InspectorControls,
+                null,
+                el(
+                    PanelBody,
+                    { title: __( 'Lecture automatique', 'lightbox-jlg' ), initialOpen: true },
+                    el( ToggleControl, {
+                        label: __( 'Activer l’autoplay', 'lightbox-jlg' ),
+                        checked: typeof attributes.autoplay === 'boolean' ? attributes.autoplay : defaultAutoplay,
+                        onChange: onToggle( 'autoplay' )
+                    } ),
+                    el( RangeControl, {
+                        label: __( 'Délai entre les images (secondes)', 'lightbox-jlg' ),
+                        min: 1,
+                        max: 30,
+                        value: attributes.delay || defaultDelay,
+                        onChange: function( value ) {
+                            var parsed = parseInt( value, 10 );
+                            if ( ! parsed || parsed < 1 ) {
+                                parsed = 1;
+                            }
+                            if ( parsed > 30 ) {
+                                parsed = 30;
+                            }
+                            setAttributes( { delay: parsed } );
+                        }
+                    } ),
+                    el( ToggleControl, {
+                        label: __( 'Lecture en boucle', 'lightbox-jlg' ),
+                        checked: typeof attributes.loop === 'boolean' ? attributes.loop : defaultLoop,
+                        onChange: onToggle( 'loop' )
+                    } )
+                ),
+                el(
+                    PanelBody,
+                    { title: __( 'Contrôles affichés', 'lightbox-jlg' ), initialOpen: false },
+                    el( ToggleControl, {
+                        label: __( 'Zoom', 'lightbox-jlg' ),
+                        checked: typeof attributes.showZoom === 'boolean' ? attributes.showZoom : defaultZoom,
+                        onChange: onToggle( 'showZoom' )
+                    } ),
+                    el( ToggleControl, {
+                        label: __( 'Téléchargement', 'lightbox-jlg' ),
+                        checked: typeof attributes.showDownload === 'boolean' ? attributes.showDownload : defaultDownload,
+                        onChange: onToggle( 'showDownload' )
+                    } ),
+                    el( ToggleControl, {
+                        label: __( 'Partager', 'lightbox-jlg' ),
+                        checked: typeof attributes.showShare === 'boolean' ? attributes.showShare : defaultShare,
+                        onChange: onToggle( 'showShare' )
+                    } ),
+                    el( ToggleControl, {
+                        label: __( 'Plein écran', 'lightbox-jlg' ),
+                        checked: typeof attributes.showFullscreen === 'boolean' ? attributes.showFullscreen : defaultFullscreen,
+                        onChange: onToggle( 'showFullscreen' )
+                    } )
+                ),
+                el(
+                    PanelBody,
+                    { title: __( 'Style', 'lightbox-jlg' ), initialOpen: false },
+                    el( SelectControl, {
+                        label: __( 'Arrière-plan', 'lightbox-jlg' ),
+                        value: attributes.backgroundStyle || defaultBackgroundStyle,
+                        options: [
+                            { label: __( 'Écho d’image', 'lightbox-jlg' ), value: 'echo' },
+                            { label: __( 'Texture', 'lightbox-jlg' ), value: 'texture' },
+                            { label: __( 'Flou direct', 'lightbox-jlg' ), value: 'blur' }
+                        ],
+                        onChange: function( value ) {
+                            setAttributes( { backgroundStyle: value || defaultBackgroundStyle } );
+                        }
+                    } ),
+                    el( ToggleControl, {
+                        label: __( 'Miniatures sur mobile', 'lightbox-jlg' ),
+                        checked: typeof attributes.showThumbsMobile === 'boolean' ? attributes.showThumbsMobile : defaultThumbsMobile,
+                        onChange: onToggle( 'showThumbsMobile' )
+                    } ),
+                    el( RangeControl, {
+                        label: __( 'Opacité du fond', 'lightbox-jlg' ),
+                        min: 0.5,
+                        max: 1,
+                        step: 0.05,
+                        value: attributes.bgOpacity || defaultBgOpacity,
+                        onChange: function( value ) {
+                            var parsed = parseFloat( value );
+                            if ( isNaN( parsed ) ) {
+                                parsed = defaultBgOpacity;
+                            }
+                            if ( parsed < 0.5 ) {
+                                parsed = 0.5;
+                            }
+                            if ( parsed > 1 ) {
+                                parsed = 1;
+                            }
+                            setAttributes( { bgOpacity: parsed } );
+                        }
+                    } ),
+                    ColorPalette ? el(
+                        BaseControl,
+                        { label: __( 'Couleur d’accent', 'lightbox-jlg' ) },
+                        el( ColorPalette, {
+                            value: attributes.accentColor || defaultAccent,
+                            colors: palette,
+                            disableCustomColors: false,
+                            onChange: onChangeAccent
+                        } )
+                    ) : null,
+                    ( ! ColorPalette && Notice ) ? el( Notice, { status: 'warning', isDismissible: false }, __( 'Votre installation de WordPress ne propose pas de sélecteur de couleur compatible.', 'lightbox-jlg' ) ) : null
+                )
+            ) : null,
+            el(
+                'div',
+                blockProps,
+                el( Preview, { attributes: attributes } )
+            )
+        );
+    }
+
+    registerBlockType( 'ma-galerie-automatique/lightbox-preview', {
+        title: __( 'Lightbox – Aperçu', 'lightbox-jlg' ),
+        description: __( 'Simulez la visionneuse en direct dans l’éditeur pour vérifier vos réglages.', 'lightbox-jlg' ),
+        icon: 'format-gallery',
+        category: 'media',
+        keywords: [ __( 'lightbox', 'lightbox-jlg' ), __( 'galerie', 'lightbox-jlg' ), __( 'aperçu', 'lightbox-jlg' ) ],
+        supports: {
+            align: [ 'wide', 'full' ],
+            html: false
+        },
+        attributes: {
+            autoplay: { type: 'boolean', default: defaultAutoplay },
+            loop: { type: 'boolean', default: defaultLoop },
+            delay: { type: 'number', default: defaultDelay },
+            backgroundStyle: { type: 'string', default: defaultBackgroundStyle },
+            accentColor: { type: 'string', default: defaultAccent },
+            bgOpacity: { type: 'number', default: defaultBgOpacity },
+            showThumbsMobile: { type: 'boolean', default: defaultThumbsMobile },
+            showZoom: { type: 'boolean', default: defaultZoom },
+            showDownload: { type: 'boolean', default: defaultDownload },
+            showShare: { type: 'boolean', default: defaultShare },
+            showFullscreen: { type: 'boolean', default: defaultFullscreen }
+        },
+        edit: Edit,
+        save: function() {
+            return null;
+        }
+    } );
+
+    root.mgaLightboxPreview = {
+        Preview: Preview,
+        defaults: defaults
+    };
+} )();

--- a/ma-galerie-automatique/includes/Frontend/Assets.php
+++ b/ma-galerie-automatique/includes/Frontend/Assets.php
@@ -231,7 +231,7 @@ class Assets {
         wp_register_script(
             $script_handle,
             $this->plugin->get_plugin_dir_url() . 'assets/js/block-editor-preview.js',
-            [ 'wp-dom-ready', 'wp-data', 'wp-i18n' ],
+            [ 'wp-element', 'wp-data', 'wp-i18n', 'wp-hooks', 'wp-compose', 'wp-block-editor' ],
             MGA_VERSION,
             true
         );
@@ -239,6 +239,7 @@ class Assets {
         $localization = [
             'noteText'        => \__( 'Lightbox active', 'lightbox-jlg' ),
             'supportedBlocks' => $allowed_block_names,
+            'previewBlockName' => 'ma-galerie-automatique/lightbox-preview',
         ];
 
         wp_localize_script( $script_handle, 'mgaBlockEditorPreview', $localization );

--- a/ma-galerie-automatique/includes/Plugin.php
+++ b/ma-galerie-automatique/includes/Plugin.php
@@ -33,6 +33,7 @@ class Plugin {
         add_action( 'admin_menu', [ $this->settings, 'add_admin_menu' ] );
         add_action( 'admin_init', [ $this->settings, 'register_settings' ] );
         add_action( 'admin_enqueue_scripts', [ $this->settings, 'enqueue_assets' ] );
+        add_action( 'init', [ $this, 'register_block' ] );
     }
 
     public function activate(): void {
@@ -97,5 +98,61 @@ class Plugin {
 
     public function frontend_assets(): Assets {
         return $this->frontend_assets;
+    }
+
+    public function register_block(): void {
+        if ( ! function_exists( 'register_block_type' ) ) {
+            return;
+        }
+
+        $script_handle = 'mga-lightbox-editor-block';
+        $style_handle  = 'mga-lightbox-editor-block';
+
+        wp_register_script(
+            $script_handle,
+            $this->get_plugin_dir_url() . 'assets/js/block/index.js',
+            [ 'wp-blocks', 'wp-element', 'wp-i18n', 'wp-components', 'wp-block-editor', 'wp-compose', 'wp-data' ],
+            MGA_VERSION,
+            true
+        );
+
+        wp_register_style(
+            $style_handle,
+            $this->get_plugin_dir_url() . 'assets/css/block/editor.css',
+            [ 'wp-edit-blocks' ],
+            MGA_VERSION
+        );
+
+        $defaults = $this->settings->get_default_settings();
+
+        $localization = [
+            'accentColor'      => $defaults['accent_color'] ?? '#ffffff',
+            'backgroundStyle'  => $defaults['background_style'] ?? 'echo',
+            'autoplay'         => (bool) ( $defaults['autoplay_start'] ?? false ),
+            'loop'             => (bool) ( $defaults['loop'] ?? true ),
+            'delay'            => (int) ( $defaults['delay'] ?? 4 ),
+            'bgOpacity'        => isset( $defaults['bg_opacity'] ) ? (float) $defaults['bg_opacity'] : 0.95,
+            'showThumbsMobile' => (bool) ( $defaults['show_thumbs_mobile'] ?? true ),
+            'showZoom'         => (bool) ( $defaults['show_zoom'] ?? true ),
+            'showDownload'     => (bool) ( $defaults['show_download'] ?? true ),
+            'showShare'        => (bool) ( $defaults['show_share'] ?? true ),
+            'showFullscreen'   => (bool) ( $defaults['show_fullscreen'] ?? true ),
+            'noteText'         => \__( 'Lightbox active', 'lightbox-jlg' ),
+        ];
+
+        wp_localize_script( $script_handle, 'mgaBlockDefaults', $localization );
+
+        if ( $this->languages_directory_exists() ) {
+            wp_set_script_translations( $script_handle, 'lightbox-jlg', $this->get_languages_path() );
+        }
+
+        register_block_type(
+            'ma-galerie-automatique/lightbox-preview',
+            [
+                'editor_script'   => $script_handle,
+                'editor_style'    => $style_handle,
+                'render_callback' => '__return_empty_string',
+            ]
+        );
     }
 }

--- a/ma-galerie-automatique/includes/admin-page-template.php
+++ b/ma-galerie-automatique/includes/admin-page-template.php
@@ -424,6 +424,14 @@ $settings = wp_parse_args( $settings, $defaults );
             <h3><?php echo esc_html__( "C'est tout !", 'lightbox-jlg' ); ?></h3>
             <p><?php echo esc_html__( "Désormais, sur votre site, lorsque qu'un visiteur cliquera sur l'une de ces images, la visionneuse (lightbox) s'ouvrira et affichera toutes les autres images de l'article qui ont également été liées à leur &quot;Fichier média&quot;.", 'lightbox-jlg' ); ?></p>
 
+            <h3><?php echo esc_html__( 'Bloc de prévisualisation Gutenberg', 'lightbox-jlg' ); ?></h3>
+            <p><?php echo wp_kses_post( __( 'Besoin de vérifier vos réglages sans quitter l’éditeur&nbsp;? Ajoutez le bloc <strong>«&nbsp;Lightbox – Aperçu&nbsp;»</strong> depuis l’onglet <em>Médias</em>. Il simule la visionneuse avec vos paramètres (lecture automatique, contrôles, style d’arrière-plan, etc.) directement dans Gutenberg.', 'lightbox-jlg' ) ); ?></p>
+            <p><?php echo wp_kses_post( __( 'Chaque option clé est disponible dans la colonne latérale du bloc. Ajustez l’autoplay, choisissez les boutons à afficher, modifiez la couleur d’accent ou l’opacité du fond&nbsp;: l’aperçu se met à jour immédiatement pour refléter le rendu réel.', 'lightbox-jlg' ) ); ?></p>
+            <p><?php echo wp_kses_post( __( 'Le bloc est purement éditorial&nbsp;: il n’ajoute aucun contenu supplémentaire sur le site publié. Il vous aide simplement à présenter la lightbox à vos clients ou collaborateurs depuis l’éditeur.', 'lightbox-jlg' ) ); ?></p>
+
+            <h4><?php echo esc_html__( 'Compatibilité avec les blocs natifs', 'lightbox-jlg' ); ?></h4>
+            <p><?php echo wp_kses_post( __( 'La détection automatique reste active sur les blocs <code>core/gallery</code>, <code>core/image</code>, <code>core/media-text</code> ou <code>core/cover</code> lorsque les images renvoient vers leur fichier média. Les blocs mis en évidence dans Gutenberg portent une pastille «&nbsp;Lightbox active&nbsp;», confirmant que la visionneuse se déclenchera à la publication.', 'lightbox-jlg' ) ); ?></p>
+
             <h4><?php echo esc_html__( 'Astuce pour les légendes', 'lightbox-jlg' ); ?></h4>
             <p><?php echo wp_kses_post( __( 'La légende affichée dans la galerie est récupérée automatiquement depuis le champ <strong>&quot;Légende&quot;</strong> de votre image dans l’éditeur, ou, si celui-ci est vide, depuis le champ <strong>&quot;Texte alternatif&quot;</strong>. Pensez à les remplir !', 'lightbox-jlg' ) ); ?></p>
         </div>


### PR DESCRIPTION
## Summary
- add the “Lightbox – Aperçu” Gutenberg block with an inline lightbox simulation and inspector controls for autoplay, controls and styles
- register the new block assets in PHP, localize default settings and refactor the editor preview script to rely on BlockListBlock filters instead of DOM mutations
- refresh the tutorial and README to document the block workflow and compatibility with native gallery blocks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de8ac9e384832eb7b67e7a377f8e8d