### PR TITLE
Improve content selector customization UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Lightbox - JLG est un plugin WordPress qui transforme les galeries d'images en d
 - **Effets d’arrière-plan** : flou d’écho, texture ou flou en temps réel.
 - **Lecture en boucle** et **lancement automatique** du diaporama.
 - **Z‑index** de la galerie et **mode débogage**.
-- **Sélecteurs CSS personnalisés** : complétez la liste par défaut lorsque votre thème encapsule le contenu dans des conteneurs non standards (ex. `.site-main > .article-body`). Saisissez-les dans le champ multi-lignes (un sélecteur par ligne) ou utilisez le bouton **Ajouter un sélecteur** pour alimenter la liste dynamique.
+- **Sélecteurs CSS personnalisés** : complétez la liste par défaut lorsque votre thème encapsule le contenu dans des conteneurs non standards (ex. `.site-main > .article-body`). Collez-les dans le champ multi-lignes (un sélecteur par ligne), cliquez sur **Ajouter un sélecteur** ou appuyez sur la touche **Entrée** depuis un champ pour alimenter la liste dynamique.
 
 ## Fonctionnalités
 La visionneuse plein écran pilotée par `assets/js/gallery-slideshow.js` et mise en forme par `assets/css/gallery-slideshow.css` offre les contrôles suivants :
@@ -68,7 +68,7 @@ Ces filtres permettent d'adapter le comportement du plugin selon vos besoins.
 
 ### Quand ajuster les sélecteurs CSS ?
 
-Si votre thème n’utilise pas les classes habituelles comme `.entry-content`, `.page-content` ou `.post-content`, la détection automatique peut ignorer certaines images liées. Dans ce cas, ouvrez **Réglages → Ma Galerie Automatique** puis ajoutez vos propres sélecteurs CSS dans le champ **Sélecteurs CSS personnalisés**. Vous pouvez coller plusieurs sélecteurs en les séparant par des retours à la ligne ou cliquer sur **Ajouter un sélecteur** pour gérer la liste champ par champ. Le plugin combinera ces sélecteurs avec ceux fournis par défaut pour localiser les images prêtes à ouvrir la lightbox.
+Si votre thème n’utilise pas les classes habituelles comme `.entry-content`, `.page-content` ou `.post-content`, la détection automatique peut ignorer certaines images liées. Dans ce cas, ouvrez **Réglages → Ma Galerie Automatique** puis ajoutez vos propres sélecteurs CSS dans le champ **Sélecteurs CSS personnalisés**. Vous pouvez coller plusieurs sélecteurs en les séparant par des retours à la ligne, cliquer sur **Ajouter un sélecteur** ou utiliser la touche **Entrée** pour générer une nouvelle rangée à la volée. Pensez à inspecter votre page avec les outils de développement du navigateur afin d’identifier la classe englobante : le plugin combinera vos sélecteurs avec ceux fournis par défaut pour localiser les images prêtes à ouvrir la lightbox.
 
 ### `mga_swiper_css`
 - **Rôle** : modifier l'URL de la feuille de style utilisée par Swiper (locale par défaut).

--- a/ma-galerie-automatique/assets/js/admin-script.js
+++ b/ma-galerie-automatique/assets/js/admin-script.js
@@ -295,10 +295,12 @@
             const template = doc.getElementById('mga-content-selector-template');
             const placeholder = selectorsWrapper.getAttribute('data-mga-selector-placeholder') || '';
             let isSyncingSelectors = false;
+            let addRow = () => {};
 
             if (selectorsList) {
                 const queryRows = () => selectorsList.querySelectorAll('[data-mga-content-selector-row]');
                 const queryInputs = () => selectorsList.querySelectorAll('[data-mga-content-selector-input]');
+                const hasEmptyRow = () => Array.from(queryInputs()).some((input) => input.value.trim() === '');
 
                 const updateRemoveState = () => {
                     const rows = queryRows();
@@ -362,6 +364,37 @@
                         input.addEventListener('input', () => {
                             if (!isSyncingSelectors) {
                                 syncTextareaFromRows();
+                            }
+                        });
+
+                        input.addEventListener('keydown', (event) => {
+                            if (event.key !== 'Enter' || event.shiftKey || event.altKey || event.metaKey || event.ctrlKey) {
+                                return;
+                            }
+
+                            event.preventDefault();
+
+                            if (!hasEmptyRow() && typeof addRow === 'function') {
+                                addRow('');
+                                return;
+                            }
+
+                            const rows = queryRows();
+
+                            if (rows.length === 0) {
+                                return;
+                            }
+
+                            const lastRow = rows[rows.length - 1];
+
+                            if (!lastRow) {
+                                return;
+                            }
+
+                            const lastInput = lastRow.querySelector('[data-mga-content-selector-input]');
+
+                            if (lastInput && lastInput !== event.target) {
+                                safeFocus(lastInput);
                             }
                         });
 
@@ -461,7 +494,7 @@
                     isSyncingSelectors = false;
                 };
 
-                const addRow = (value = '') => {
+                addRow = (value = '') => {
                     const row = createRow(value);
 
                     if (row) {

--- a/ma-galerie-automatique/includes/Admin/Settings.php
+++ b/ma-galerie-automatique/includes/Admin/Settings.php
@@ -208,6 +208,7 @@ class Settings {
             foreach ( (array) $selectors as $selector ) {
                 $clean_selector = (string) $selector;
                 $clean_selector = wp_strip_all_tags( $clean_selector );
+                $clean_selector = str_replace( "\xC2\xA0", ' ', $clean_selector );
                 $clean_selector = preg_replace( '/[\x00-\x1F\x7F]+/u', '', $clean_selector );
                 $clean_selector = preg_replace( '/\s+/u', ' ', $clean_selector );
                 $clean_selector = trim( $clean_selector );

--- a/ma-galerie-automatique/includes/admin-page-template.php
+++ b/ma-galerie-automatique/includes/admin-page-template.php
@@ -307,7 +307,7 @@ $settings = wp_parse_args( $settings, $defaults );
                             <p class="description" id="mga-content-selectors-help">
                                 <?php
                                 echo wp_kses_post(
-                                    __( 'Ajoutez ici vos propres sélecteurs lorsque le contenu principal de votre thème n’utilise pas les classes par défaut (par exemple <code>.entry-content</code>). Chaque ligne correspond à un sélecteur complet qui sera combiné avec ceux fournis par défaut.', 'lightbox-jlg' )
+                                    __( 'Ajoutez ici vos propres sélecteurs lorsque le contenu principal de votre thème n’utilise pas les classes par défaut (par exemple <code>.entry-content</code>). Chaque ligne correspond à un sélecteur complet, combiné aux valeurs natives du plugin. Utilisez le bouton <strong>Ajouter un sélecteur</strong> ou appuyez sur la touche <kbd>Entrée</kbd> dans un champ pour créer rapidement une nouvelle ligne.', 'lightbox-jlg' )
                                 );
                                 ?>
                             </p>
@@ -316,7 +316,7 @@ $settings = wp_parse_args( $settings, $defaults );
                                 <p>
                                     <?php
                                     echo wp_kses_post(
-                                        __( 'Utilisez cette liste si votre thème encapsule les images dans des conteneurs spécifiques (ex. <code>.site-main .article-body</code>) ou si vous avez besoin d’inclure des blocs personnalisés. Le plugin parcourra chaque sélecteur pour repérer les liens vers des fichiers médias.', 'lightbox-jlg' )
+                                        __( 'Utilisez cette liste si votre thème encapsule les images dans des conteneurs spécifiques (ex. <code>.site-main .article-body</code>) ou si vous avez besoin d’inclure des blocs personnalisés. En cas de doute, inspectez votre page avec les outils du navigateur pour identifier la classe englobante, puis ajoutez-la ici afin que le plugin repère les liens vers les fichiers médias.', 'lightbox-jlg' )
                                     );
                                     ?>
                                 </p>


### PR DESCRIPTION
## Summary
- make the admin content selector repeater easier to use with keyboard shortcuts while keeping the textarea in sync
- normalise non-breaking spaces when sanitising custom selectors coming from arrays or newline separated values
- clarify when and how to extend the selector list in the admin help text and README

## Testing
- npm run test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68de9f53cc28832ea0711f3bf0901a1c