### PR TITLE
Improve fallback sprintf placeholder handling

### DIFF
--- a/ma-galerie-automatique/assets/js/admin-script.js
+++ b/ma-galerie-automatique/assets/js/admin-script.js
@@ -2,12 +2,13 @@
 (function(global) {
     const mgaAdminI18n = global.wp && global.wp.i18n ? global.wp.i18n : null;
     const mgaAdmin__ = mgaAdminI18n && typeof mgaAdminI18n.__ === 'function' ? mgaAdminI18n.__ : ( text ) => text;
-    const TOKEN_REGEX = /%(\d+\$)?([sd])/g;
+    const TOKEN_REGEX = /%(\d+\$)?[sd]/g;
     const fallbackSprintf = ( format, ...args ) => {
         let autoIndex = 0;
 
-        return String(format).replace(TOKEN_REGEX, (match, position, type) => {
+        return String(format).replace(TOKEN_REGEX, (match, position) => {
             let argIndex;
+            const type = match.charAt(match.length - 1);
 
             if (position) {
                 const numericIndex = parseInt(position.slice(0, -1), 10);
@@ -22,19 +23,15 @@
                 autoIndex += 1;
             }
 
-            if (argIndex < 0 || argIndex >= args.length) {
-                return '';
-            }
-
-            const value = args[argIndex];
-
-            if (typeof value === 'undefined') {
-                return '';
-            }
+            const value = argIndex >= 0 && argIndex < args.length ? args[argIndex] : undefined;
 
             if (type === 'd') {
                 const coerced = parseInt(value, 10);
                 return Number.isNaN(coerced) ? '' : String(coerced);
+            }
+
+            if (typeof value === 'undefined') {
+                return '';
             }
 
             return String(value);

--- a/ma-galerie-automatique/assets/js/debug.js
+++ b/ma-galerie-automatique/assets/js/debug.js
@@ -3,12 +3,13 @@
 
     const mgaI18n = global.wp && global.wp.i18n ? global.wp.i18n : null;
     const mga__ = mgaI18n && typeof mgaI18n.__ === 'function' ? mgaI18n.__ : ( text ) => text;
-    const TOKEN_REGEX = /%(\d+\$)?([sd])/g;
+    const TOKEN_REGEX = /%(\d+\$)?[sd]/g;
     const fallbackSprintf = ( format, ...args ) => {
         let autoIndex = 0;
 
-        return String(format).replace(TOKEN_REGEX, (match, position, type) => {
+        return String(format).replace(TOKEN_REGEX, (match, position) => {
             let argIndex;
+            const type = match.charAt(match.length - 1);
 
             if (position) {
                 const numericIndex = parseInt(position.slice(0, -1), 10);
@@ -23,19 +24,15 @@
                 autoIndex += 1;
             }
 
-            if (argIndex < 0 || argIndex >= args.length) {
-                return '';
-            }
-
-            const value = args[argIndex];
-
-            if (typeof value === 'undefined') {
-                return '';
-            }
+            const value = argIndex >= 0 && argIndex < args.length ? args[argIndex] : undefined;
 
             if (type === 'd') {
                 const coerced = parseInt(value, 10);
                 return Number.isNaN(coerced) ? '' : String(coerced);
+            }
+
+            if (typeof value === 'undefined') {
+                return '';
             }
 
             return String(value);

--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -3,12 +3,13 @@
 
     const mgaI18n = window.wp && window.wp.i18n ? window.wp.i18n : null;
     const mga__ = mgaI18n && typeof mgaI18n.__ === 'function' ? mgaI18n.__ : ( text ) => text;
-    const TOKEN_REGEX = /%(\d+\$)?([sd])/g;
+    const TOKEN_REGEX = /%(\d+\$)?[sd]/g;
     const fallbackSprintf = ( format, ...args ) => {
         let autoIndex = 0;
 
-        return String(format).replace(TOKEN_REGEX, (match, position, type) => {
+        return String(format).replace(TOKEN_REGEX, (match, position) => {
             let argIndex;
+            const type = match.charAt(match.length - 1);
 
             if (position) {
                 const numericIndex = parseInt(position.slice(0, -1), 10);
@@ -23,19 +24,15 @@
                 autoIndex += 1;
             }
 
-            if (argIndex < 0 || argIndex >= args.length) {
-                return '';
-            }
-
-            const value = args[argIndex];
-
-            if (typeof value === 'undefined') {
-                return '';
-            }
+            const value = argIndex >= 0 && argIndex < args.length ? args[argIndex] : undefined;
 
             if (type === 'd') {
                 const coerced = parseInt(value, 10);
                 return Number.isNaN(coerced) ? '' : String(coerced);
+            }
+
+            if (typeof value === 'undefined') {
+                return '';
             }
 
             return String(value);


### PR DESCRIPTION
## Summary
- update the fallback sprintf helper to recognise both numbered and unnumbered placeholders
- coerce numeric placeholders to integers and default missing values to an empty string across admin, debug, and slideshow scripts

## Testing
- node - <<'NODE'


------
https://chatgpt.com/codex/tasks/task_e_68dea2dd6af0832e9a4d9fc36363a4a7