### PR TITLE
Adjust mobile spacing based on caption presence

### DIFF
--- a/ma-galerie-automatique/assets/css/gallery-slideshow.css
+++ b/ma-galerie-automatique/assets/css/gallery-slideshow.css
@@ -210,12 +210,23 @@
         white-space: normal;
     }
     /* Correction : on cible bien .mga-main-swiper pour l'affichage mobile en mode portrait */
-    .mga-main-swiper {
+    .mga-viewer.mga-has-caption .mga-main-swiper {
         margin-top: calc(110px + env(safe-area-inset-top, 0px) + env(safe-area-inset-bottom, 0px));
+    }
+    .mga-viewer:not(.mga-has-caption) .mga-main-swiper {
+        margin-top: calc(70px + env(safe-area-inset-top, 0px));
+    }
+    .mga-main-swiper {
         max-height: calc(100vh - (var(--mga-thumb-size-mobile, 70px) + 130px + env(safe-area-inset-bottom, 0px)));
     }
     .mga-viewer.mga-hide-thumbs-mobile .mga-main-swiper {
         max-height: calc(100vh - (130px + env(safe-area-inset-bottom, 0px)));
+    }
+    .mga-viewer.mga-hide-thumbs-mobile.mga-has-caption .mga-main-swiper {
+        margin-top: calc(110px + env(safe-area-inset-top, 0px) + env(safe-area-inset-bottom, 0px));
+    }
+    .mga-viewer.mga-hide-thumbs-mobile:not(.mga-has-caption) .mga-main-swiper {
+        margin-top: calc(70px + env(safe-area-inset-top, 0px));
     }
     .mga-thumbs-swiper {
         height: calc(var(--mga-thumb-size-mobile, 70px) + env(safe-area-inset-bottom, 0px));

--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -879,6 +879,7 @@
                 viewer = document.createElement('div');
                 viewer.id = 'mga-viewer';
                 viewer.className = 'mga-viewer';
+                viewer.classList.toggle('mga-has-caption', false);
                 viewer.style.display = 'none';
                 viewer.setAttribute('role', 'dialog');
                 viewer.setAttribute('aria-modal', 'true');
@@ -1935,7 +1936,7 @@
         }
 
         function updateInfo(viewer, images, index) {
-            if (!images[index]) {
+            if (!viewer || !images[index]) {
                 return;
             }
 
@@ -1946,6 +1947,7 @@
 
             const imageData = images[index];
             const captionText = imageData.caption || '';
+            viewer.classList.toggle('mga-has-caption', Boolean(captionText));
             const counterText = mgaSprintf(mga__( '%1$s / %2$s', 'lightbox-jlg' ), index + 1, images.length);
             const announcementCounterText = mgaSprintf(mga__( 'Image %1$s sur %2$s', 'lightbox-jlg' ), index + 1, images.length);
             const announcementText = captionText ? `${announcementCounterText}. ${captionText}` : announcementCounterText;


### PR DESCRIPTION
## Summary
- toggle a CSS helper class on the viewer to reflect when a caption is available
- update mobile spacing rules for the slideshow so the main swiper gains space when no caption is displayed, including in hide-thumbs mode

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68debe2e650c832ea70e9cd3c4325d3c