### PR TITLE
Align block preview toolbar icons with lightbox visuals

### DIFF
--- a/ma-galerie-automatique/assets/css/block/editor.css
+++ b/ma-galerie-automatique/assets/css/block/editor.css
@@ -69,7 +69,18 @@
 }
 
 .mga-block-preview__viewer .mga-toolbar-button .mga-icon {
-    font-size: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+}
+
+.mga-block-preview__viewer .mga-toolbar-button .mga-icon svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+    fill: currentColor;
 }
 
 .mga-block-preview__viewer .mga-main-swiper {

--- a/ma-galerie-automatique/assets/js/block/index.js
+++ b/ma-galerie-automatique/assets/js/block/index.js
@@ -114,7 +114,64 @@
         }, [] ) || [];
     }
 
-    function renderToolbarButton( icon, label ) {
+    var ICON_DEFINITIONS = {
+        play: {
+            viewBox: '0 0 24 24',
+            paths: [ { d: 'M8 5v14l11-7z' } ]
+        },
+        pause: {
+            viewBox: '0 0 24 24',
+            paths: [ { d: 'M6 19h4V5H6v14zm8-14v14h4V5h-4z' } ]
+        },
+        zoom: {
+            viewBox: '0 0 24 24',
+            paths: [
+                { d: 'M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z' },
+                { d: 'M10 9h-1v-1H8v1H7v1h1v1h1v-1h1V9z' }
+            ]
+        },
+        download: {
+            viewBox: '0 0 24 24',
+            paths: [ { d: 'M5 20h14v-2H5v2zm7-16l-5 5h3v4h4v-4h3l-5-5z' } ]
+        },
+        share: {
+            viewBox: '0 0 24 24',
+            paths: [ { d: 'M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.02-4.11A2.99 2.99 0 0 0 18 7.91c1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.03.47.09.7L8.07 9.7A2.99 2.99 0 0 0 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.03-.82l7.05 4.12c-.06.23-.08.46-.08.7 0 1.65 1.34 2.99 3 2.99s3-1.34 3-2.99-1.34-3-3-3z' } ]
+        },
+        fullscreen: {
+            viewBox: '0 0 24 24',
+            paths: [ { d: 'M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5V14h-2v3zM14 5v2h3v3h2V5h-5z' } ]
+        },
+        close: {
+            viewBox: '0 0 24 24',
+            paths: [ { d: 'M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z' } ]
+        }
+    };
+
+    function renderToolbarButton( iconName, label ) {
+        var iconDefinition = ICON_DEFINITIONS[ iconName ] || null;
+        var svgChildren = [];
+
+        if ( iconDefinition && iconDefinition.paths ) {
+            for ( var i = 0; i < iconDefinition.paths.length; i++ ) {
+                var pathDefinition = iconDefinition.paths[ i ];
+                var pathProps = { d: pathDefinition.d };
+                svgChildren.push( el( 'path', pathProps ) );
+            }
+        }
+
+        var svgElement = iconDefinition
+            ? el.apply( null, [
+                'svg',
+                {
+                    xmlns: 'http://www.w3.org/2000/svg',
+                    viewBox: iconDefinition.viewBox,
+                    fill: 'currentColor',
+                    focusable: 'false'
+                }
+            ].concat( svgChildren ) )
+            : iconName;
+
         return el(
             'button',
             {
@@ -123,7 +180,7 @@
                 disabled: true,
                 'aria-disabled': 'true'
             },
-            el( 'span', { className: 'mga-icon', 'aria-hidden': 'true' }, icon ),
+            el( 'span', { className: 'mga-icon', 'aria-hidden': 'true' }, svgElement ),
             el( 'span', { className: 'mga-screen-reader-text' }, label )
         );
     }
@@ -210,11 +267,12 @@
                     el(
                         'div',
                         { className: 'mga-toolbar' },
-                        autoplay ? renderToolbarButton( '⏸', __( 'Mettre en pause', 'lightbox-jlg' ) ) : renderToolbarButton( '▶', __( 'Lire', 'lightbox-jlg' ) ),
-                        showZoom ? renderToolbarButton( '🔍', __( 'Zoomer', 'lightbox-jlg' ) ) : null,
-                        showDownload ? renderToolbarButton( '⬇', __( 'Télécharger', 'lightbox-jlg' ) ) : null,
-                        showShare ? renderToolbarButton( '⤴', __( 'Partager', 'lightbox-jlg' ) ) : null,
-                        showFullscreen ? renderToolbarButton( '⤢', __( 'Plein écran', 'lightbox-jlg' ) ) : null
+                        autoplay ? renderToolbarButton( 'pause', __( 'Mettre en pause', 'lightbox-jlg' ) ) : renderToolbarButton( 'play', __( 'Lire', 'lightbox-jlg' ) ),
+                        showZoom ? renderToolbarButton( 'zoom', __( 'Zoomer', 'lightbox-jlg' ) ) : null,
+                        showDownload ? renderToolbarButton( 'download', __( 'Télécharger', 'lightbox-jlg' ) ) : null,
+                        showShare ? renderToolbarButton( 'share', __( 'Partager', 'lightbox-jlg' ) ) : null,
+                        showFullscreen ? renderToolbarButton( 'fullscreen', __( 'Plein écran', 'lightbox-jlg' ) ) : null,
+                        renderToolbarButton( 'close', __( 'Fermer', 'lightbox-jlg' ) )
                     )
                 ),
                 el(


### PR DESCRIPTION
## Summary
- replace the block preview toolbar glyphs with the SVG icons used by the lightbox (play/pause, zoom, download, share, fullscreen, close)
- update the editor preview toolbar markup to include the close control and reuse the shared icon definitions
- tweak editor styles so the new SVG-based toolbar icons remain centered and sized consistently

## Testing
- `npx wp-scripts build`


------
https://chatgpt.com/codex/tasks/task_e_68debe305dc8832e9c5c86395de0613b