### PR TITLE
Improve swiper navigation accessibility and mobile layout

### DIFF
--- a/ma-galerie-automatique/assets/css/gallery-slideshow.css
+++ b/ma-galerie-automatique/assets/css/gallery-slideshow.css
@@ -110,9 +110,30 @@
 @keyframes mga-spin { to { transform: rotate(360deg); } }
 
 .mga-main-swiper .swiper-button-next,
-.mga-main-swiper .swiper-button-prev { color: var(--mga-accent-color, #fff); --swiper-navigation-size: 30px; background-color: rgba(0, 0, 0, 0.3); border-radius: 50%; width: 50px; height: 50px; transition: background-color 0.2s ease; }
+.mga-main-swiper .swiper-button-prev {
+    color: var(--mga-accent-color, #fff);
+    --swiper-navigation-size: 30px;
+    background-color: rgba(0, 0, 0, 0.3);
+    border-radius: 50%;
+    width: 50px;
+    height: 50px;
+    border: 0;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.2s ease, transform 0.2s ease;
+    touch-action: manipulation;
+    z-index: 25;
+    cursor: pointer;
+}
 .mga-main-swiper .swiper-button-next:hover,
 .mga-main-swiper .swiper-button-prev:hover { background-color: rgba(0, 0, 0, 0.6); }
+.mga-main-swiper .swiper-button-next:focus-visible,
+.mga-main-swiper .swiper-button-prev:focus-visible {
+    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.55);
+    outline: none;
+}
 
 .mga-thumbs-swiper {
     height: calc(var(--mga-thumb-size-desktop, 90px) + env(safe-area-inset-bottom, 0px));
@@ -234,10 +255,20 @@
     .mga-viewer.mga-hide-thumbs-mobile .mga-thumbs-swiper {
         height: auto;
     }
-    .mga-main-swiper .swiper-button-next, .mga-main-swiper .swiper-button-prev { display: none; }
+    .mga-main-swiper .swiper-button-next,
+    .mga-main-swiper .swiper-button-prev {
+        top: auto;
+        bottom: calc(var(--mga-thumb-size-mobile, 70px) + 24px + env(safe-area-inset-bottom, 0px));
+        transform: translateY(0);
+        width: 56px;
+        height: 56px;
+        background-color: rgba(0, 0, 0, 0.45);
+    }
+    .mga-main-swiper .swiper-button-next { right: clamp(16px, 6vw, 32px); }
+    .mga-main-swiper .swiper-button-prev { left: clamp(16px, 6vw, 32px); }
     .mga-viewer.mga-hide-thumbs-mobile .mga-main-swiper .swiper-button-next,
     .mga-viewer.mga-hide-thumbs-mobile .mga-main-swiper .swiper-button-prev {
-        display: flex;
+        bottom: calc(24px + env(safe-area-inset-bottom, 0px));
     }
 }
 
@@ -269,6 +300,14 @@
     .mga-viewer.mga-hide-thumbs-mobile .mga-main-swiper {
         max-height: calc(100vh - (80px + env(safe-area-inset-bottom, 0px)));
     }
+    .mga-main-swiper .swiper-button-next,
+    .mga-main-swiper .swiper-button-prev {
+        top: 50%;
+        bottom: auto;
+        transform: translateY(-50%);
+        width: 54px;
+        height: 54px;
+    }
 }
 
 @media (max-width: 480px) {
@@ -281,6 +320,11 @@
         min-width: 40px;
         min-height: 40px;
         padding: 8px;
+    }
+    .mga-main-swiper .swiper-button-next,
+    .mga-main-swiper .swiper-button-prev {
+        width: 52px;
+        height: 52px;
     }
 }
 

--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -1673,16 +1673,20 @@
                 mainWrapper.id = 'mga-main-wrapper';
                 mainSwiper.appendChild(mainWrapper);
 
-                const nextButton = document.createElement('div');
-                nextButton.className = 'swiper-button-next';
+                const nextButton = document.createElement('button');
+                nextButton.type = 'button';
+                nextButton.className = 'swiper-button-next mga-nav-button';
                 nextButton.id = 'mga-next';
                 nextButton.setAttribute('aria-label', mga__( 'Image suivante', 'lightbox-jlg' ));
+                nextButton.setAttribute('title', mga__( 'Image suivante', 'lightbox-jlg' ));
                 mainSwiper.appendChild(nextButton);
 
-                const prevButton = document.createElement('div');
-                prevButton.className = 'swiper-button-prev';
+                const prevButton = document.createElement('button');
+                prevButton.type = 'button';
+                prevButton.className = 'swiper-button-prev mga-nav-button';
                 prevButton.id = 'mga-prev';
                 prevButton.setAttribute('aria-label', mga__( 'Image précédente', 'lightbox-jlg' ));
+                prevButton.setAttribute('title', mga__( 'Image précédente', 'lightbox-jlg' ));
                 mainSwiper.appendChild(prevButton);
 
                 const thumbsSwiper = document.createElement('div');


### PR DESCRIPTION
## Summary
- restyle swiper navigation controls so they stay visible on touch screens and add focus styles
- convert swiper navigation elements into buttons with accessible labels
- tweak responsive positioning of navigation relative to thumbnails and captions to avoid overlap

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68def9cc8730832e98c41d3ca48aee49