### PR TITLE
feat: rendre la configuration des canaux de partage dynamique

### DIFF
--- a/ma-galerie-automatique/assets/css/admin-style.css
+++ b/ma-galerie-automatique/assets/css/admin-style.css
@@ -38,33 +38,125 @@
     margin: 4px 0 0 28px;
 }
 
-.mga-share-channels {
+
+.mga-share-repeater {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 16px;
     margin-top: 12px;
 }
 
-.mga-share-channels__item {
+.mga-share-repeater__list {
     display: flex;
     flex-direction: column;
-    gap: 6px;
-    padding: 12px;
+    gap: 16px;
+}
+
+.mga-share-repeater__item {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 16px;
     border: 1px solid #dcdcde;
-    border-radius: 6px;
+    border-radius: 8px;
     background-color: #fff;
 }
 
-.mga-share-channels__toggle {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
+.mga-share-repeater__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.mga-share-repeater__title {
+    margin: 0;
+    font-size: 1rem;
     font-weight: 600;
 }
 
-.mga-share-channels__template {
-    max-width: 100%;
-    width: 100%;
+.mga-share-repeater__controls {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.mga-share-repeater__controls .button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.mga-share-repeater__controls .button span[aria-hidden="true"] {
+    font-size: 0.85rem;
+    line-height: 1;
+}
+
+.mga-share-repeater__controls .button-link-delete {
+    color: #b32d2e;
+}
+
+.mga-share-repeater__controls .button-link-delete:hover,
+.mga-share-repeater__controls .button-link-delete:focus {
+    color: #8a2425;
+}
+
+.mga-share-repeater__fields {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.mga-share-repeater__field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.mga-share-repeater__field--full {
+    grid-column: 1 / -1;
+}
+
+.mga-share-repeater__field--checkbox {
+    align-self: flex-end;
+}
+
+.mga-share-repeater__icon-picker {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.mga-share-repeater__icon-picker select {
+    min-width: 160px;
+}
+
+.mga-share-repeater__icon-preview {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: #f0f0f1;
+    color: #1d2327;
+}
+
+.mga-share-repeater__icon-preview svg {
+    width: 18px;
+    height: 18px;
+}
+
+.mga-share-repeater__checkbox {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 600;
+}
+
+.mga-share-repeater__add {
+    align-self: flex-start;
 }
 
 .mga-share-actions {

--- a/ma-galerie-automatique/assets/css/gallery-slideshow.css
+++ b/ma-galerie-automatique/assets/css/gallery-slideshow.css
@@ -405,6 +405,43 @@
     transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
 }
 
+.mga-share-option__content {
+    display: inline-flex;
+    align-items: center;
+    gap: 14px;
+    flex: 1;
+    min-width: 0;
+}
+
+.mga-share-option__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.12);
+    color: inherit;
+}
+
+.mga-share-option__icon svg {
+    width: 20px;
+    height: 20px;
+}
+
+.mga-share-option__label {
+    font-weight: 600;
+    text-align: left;
+    flex: 1;
+    min-width: 0;
+}
+
+.mga-share-option__chevron {
+    font-size: 1.4rem;
+    line-height: 1;
+    opacity: 0.7;
+}
+
 .mga-share-option:hover {
     background: rgba(255, 255, 255, 0.12);
     border-color: rgba(255, 255, 255, 0.35);

--- a/ma-galerie-automatique/assets/js/admin-script.js
+++ b/ma-galerie-automatique/assets/js/admin-script.js
@@ -88,6 +88,113 @@
     }
 
     const doc = global.document;
+    const SVG_NS = 'http://www.w3.org/2000/svg';
+    const SHARE_ICON_LIBRARY = {
+        facebook: {
+            viewBox: '0 0 24 24',
+            paths: [
+                { d: 'M22 12c0-5.52-4.48-10-10-10S2 6.48 2 12c0 4.99 3.66 9.12 8.44 9.88v-6.99H8.08V12h2.36V9.88c0-2.33 1.38-3.62 3.5-3.62 0.72 0 1.48 0.13 1.48 0.13v1.63h-0.83c-0.82 0-1.08 0.51-1.08 1.04V12h1.84l-0.29 1.89h-1.55v6.99C18.34 21.12 22 16.99 22 12z' },
+            ],
+        },
+        twitter: {
+            viewBox: '0 0 24 24',
+            paths: [
+                { d: 'M22.46 6c-0.77 0.35-1.6 0.59-2.46 0.69a4.29 4.29 0 0 0 1.88-2.37 8.59 8.59 0 0 1-2.72 1.04 4.28 4.28 0 0 0-7.3 3.9 12.13 12.13 0 0 1-8.82-4.47 4.28 4.28 0 0 0 1.33 5.72 4.25 4.25 0 0 1-1.94-0.54v0.05a4.28 4.28 0 0 0 3.43 4.2 4.3 4.3 0 0 1-1.93 0.07 4.28 4.28 0 0 0 4 2.97 8.58 8.58 0 0 1-5.3 1.83 12.1 12.1 0 0 0 6.56 1.92c7.88 0 12.2-6.53 12.2-12.2 0-0.19-0.01-0.39-0.01-0.58A8.7 8.7 0 0 0 22.46 6z' },
+            ],
+        },
+        linkedin: {
+            viewBox: '0 0 24 24',
+            paths: [
+                { d: 'M20.45 3H3.55A1.55 1.55 0 0 0 2 4.55v14.9C2 20.3 2.7 21 3.55 21h16.9c0.85 0 1.55-0.7 1.55-1.55V4.55C22 3.7 21.3 3 20.45 3zM8.34 18H5.67V9.67h2.67V18zM7 8.5a1.55 1.55 0 1 1 0-3.1 1.55 1.55 0 0 1 0 3.1zM18.33 18h-2.67v-4.1c0-0.98-0.02-2.24-1.36-2.24-1.36 0-1.56 1.06-1.56 2.16V18h-2.67V9.67h2.56v1.14h0.04c0.36-0.68 1.24-1.4 2.56-1.4 2.74 0 3.25 1.8 3.25 4.13V18z' },
+            ],
+        },
+        pinterest: {
+            viewBox: '0 0 24 24',
+            paths: [
+                { d: 'M12 2C6.48 2 2 6.31 2 11.42c0 3.89 2.68 7.23 6.44 8.41-0.09-0.71-0.17-1.8 0.03-2.58 0.18-0.77 1.15-4.9 1.15-4.9s-0.29-0.58-0.29-1.45c0-1.36 0.79-2.37 1.78-2.37 0.84 0 1.24 0.63 1.24 1.38 0 0.84-0.53 2.09-0.8 3.25-0.23 1 0.5 1.81 1.48 1.81 1.78 0 3.14-1.87 3.14-4.57 0-2.39-1.72-4.07-4.18-4.07-2.85 0-4.52 2.14-4.52 4.35 0 0.86 0.33 1.79 0.74 2.29 0.08 0.1 0.09 0.19 0.07 0.29-0.07 0.31-0.23 1-0.26 1.13-0.04 0.18-0.14 0.22-0.32 0.13-1.2-0.56-1.95-2.29-1.95-3.68 0-3 2.18-5.76 6.29-5.76 3.3 0 5.87 2.35 5.87 5.5 0 3.28-2.06 5.93-4.92 5.93-0.96 0-1.86-0.5-2.17-1.08l-0.59 2.24c-0.21 0.83-0.78 1.87-1.16 2.5 0.87 0.27 1.78 0.42 2.72 0.42 5.52 0 10-4.31 10-9.42C22 6.31 17.52 2 12 2z' },
+            ],
+        },
+        whatsapp: {
+            viewBox: '0 0 24 24',
+            paths: [
+                { d: 'M20.52 3.48A10.5 10.5 0 0 0 2.47 13.3l-1.45 5.28 5.4-1.41A10.5 10.5 0 1 0 20.52 3.48zm-8.5 17.54a8.75 8.75 0 0 1-4.46-1.22l-0.32-0.19-3.21 0.84 0.86-3.13-0.2-0.32a8.75 8.75 0 1 1 7.33 3.99zm4.78-6.53c-0.26-0.13-1.53-0.76-1.77-0.84-0.24-0.09-0.41-0.13-0.58 0.13-0.17 0.26-0.66 0.84-0.8 1.02-0.15 0.17-0.29 0.2-0.55 0.07-0.26-0.13-1.09-0.4-2.07-1.3-0.76-0.68-1.27-1.52-1.42-1.78-0.15-0.26-0.02-0.4 0.11-0.53 0.11-0.11 0.26-0.29 0.39-0.43 0.13-0.15 0.17-0.26 0.26-0.43 0.09-0.17 0.04-0.32-0.02-0.45-0.07-0.13-0.58-1.39-0.8-1.91-0.21-0.5-0.43-0.43-0.58-0.43-0.15 0-0.32-0.02-0.49-0.02-0.17 0-0.43 0.06-0.66 0.32-0.24 0.26-0.89 0.87-0.89 2.13s0.91 2.47 1.03 2.64c0.13 0.17 1.79 2.73 4.34 3.83 0.61 0.26 1.08 0.41 1.45 0.53 0.61 0.19 1.16 0.16 1.6 0.1 0.49-0.07 1.53-0.62 1.75-1.22 0.21-0.6 0.21-1.11 0.15-1.22-0.06-0.1-0.24-0.16-0.5-0.29z' },
+            ],
+        },
+        telegram: {
+            viewBox: '0 0 24 24',
+            paths: [
+                { d: 'M21.5 2.5l-19 7.5c-1.3 0.52-1.29 2.35 0.02 2.85l4.8 1.9 1.9 4.8c0.5 1.31 2.34 1.32 2.85 0.02l7.5-19c0.42-1.06-0.64-2.12-1.67-1.67zM10 14l-1 4-1.5-3.8 8.3-6.2-5.8 6z' },
+            ],
+        },
+        email: {
+            viewBox: '0 0 24 24',
+            paths: [
+                { d: 'M20 4H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2zm0 2-8 5-8-5h16zm0 12H4V8l8 5 8-5v10z' },
+            ],
+        },
+        link: {
+            viewBox: '0 0 24 24',
+            paths: [
+                { d: 'M10.59 13.41a1 1 0 0 1 0-1.41l2-2a1 1 0 1 1 1.41 1.41l-2 2a1 1 0 0 1-1.41 0zm-2.83 2.83a3 3 0 0 1 0-4.24l2-2a3 3 0 0 1 4.24 0 1 1 0 0 1-1.41 1.41 1 1 0 0 0-1.41 0l-2 2a1 1 0 0 0 0 1.41 1 1 0 0 0 1.41 0l1-1a1 1 0 1 1 1.41 1.41l-1 1a3 3 0 0 1-4.24 0zm8.48-8.48a3 3 0 0 0-4.24 0l-1 1a1 1 0 0 1-1.41-1.41l1-1a5 5 0 1 1 7.07 7.07l-2 2a5 5 0 0 1-7.07 0 1 1 0 0 1 1.41-1.41 3 3 0 0 0 4.24 0l2-2a3 3 0 0 0 0-4.24z' },
+            ],
+        },
+        generic: {
+            viewBox: '0 0 24 24',
+            paths: [
+                { d: 'M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2z' },
+                { d: 'M13 17h-2v-2h2zm0-4h-2V7h2z' },
+            ],
+        },
+    };
+
+    const sanitizeIconKey = (value) => {
+        if (typeof value !== 'string') {
+            return '';
+        }
+
+        return value.trim().toLowerCase().replace(/[^a-z0-9_-]/g, '');
+    };
+
+    const createSvgElement = (tag, attributes = {}) => {
+        if (!doc || typeof doc.createElementNS !== 'function') {
+            return null;
+        }
+
+        const element = doc.createElementNS(SVG_NS, tag);
+
+        Object.keys(attributes).forEach((attr) => {
+            element.setAttribute(attr, attributes[attr]);
+        });
+
+        return element;
+    };
+
+    const createShareIconPreview = (iconKey) => {
+        const sanitizedKey = sanitizeIconKey(iconKey);
+        const definition = SHARE_ICON_LIBRARY[sanitizedKey] || SHARE_ICON_LIBRARY.generic;
+        const svg = createSvgElement('svg', {
+            viewBox: definition.viewBox,
+            fill: 'currentColor',
+            'aria-hidden': 'true',
+            focusable: 'false',
+        });
+
+        if (!svg) {
+            return null;
+        }
+
+        if (Array.isArray(definition.paths)) {
+            definition.paths.forEach((pathDefinition) => {
+                const path = createSvgElement('path', pathDefinition);
+
+                if (path) {
+                    svg.appendChild(path);
+                }
+            });
+        }
+
+        return svg;
+    };
 
     const isValidHexColor = (value) => {
         if (typeof value !== 'string') {
@@ -282,6 +389,12 @@
                     applyPreviewColor(accentColorInput.value);
                 });
             }
+        }
+
+        const shareRepeater = doc.querySelector('[data-share-repeater]');
+
+        if (shareRepeater) {
+            initShareRepeater(shareRepeater);
         }
 
         const selectorsWrapper = doc.querySelector('[data-mga-content-selectors]');
@@ -529,6 +642,250 @@
                     });
                 }
             }
+        }
+        function initShareRepeater(container) {
+            const list = container.querySelector('[data-share-repeater-list]');
+            const addButton = container.querySelector('[data-share-repeater-add]');
+            const template = doc.getElementById('mga-share-channel-template');
+
+            if (!list || !template) {
+                return;
+            }
+
+            let uidSeed = Date.now();
+
+            const generateUid = () => {
+                uidSeed += 1;
+                return `mga-share-channel-${uidSeed}`;
+            };
+
+            const ensureItemUid = (item) => {
+                if (!item) {
+                    return null;
+                }
+
+                if (!item.dataset.shareUid || item.dataset.shareUid.trim() === '') {
+                    item.dataset.shareUid = generateUid();
+                }
+
+                return item.dataset.shareUid;
+            };
+
+            const applyUid = (item) => {
+                const uid = ensureItemUid(item);
+
+                if (!uid) {
+                    return;
+                }
+
+                const idElements = item.querySelectorAll('[data-share-id-suffix]');
+
+                idElements.forEach((element) => {
+                    const suffix = element.getAttribute('data-share-id-suffix');
+
+                    if (!suffix) {
+                        return;
+                    }
+
+                    const id = `${uid}-${suffix}`;
+
+                    if (element.tagName === 'LABEL') {
+                        element.setAttribute('for', id);
+                    } else {
+                        element.id = id;
+                    }
+                });
+            };
+
+            const refreshItemTitle = (item) => {
+                if (!item) {
+                    return;
+                }
+
+                const title = item.querySelector('[data-share-repeater-title]');
+
+                if (!title) {
+                    return;
+                }
+
+                const labelInput = item.querySelector('[data-share-field="label"]');
+                const keyInput = item.querySelector('[data-share-field="key"]');
+                const labelValue = labelInput && typeof labelInput.value === 'string' ? labelInput.value.trim() : '';
+                const keyValue = keyInput && typeof keyInput.value === 'string' ? keyInput.value.trim() : '';
+                const fallback = keyValue ? keyValue.toUpperCase() : mgaAdmin__('Nouveau canal', 'lightbox-jlg');
+
+                title.textContent = labelValue || fallback;
+            };
+
+            const updateIconPreview = (item) => {
+                if (!item) {
+                    return;
+                }
+
+                const preview = item.querySelector('[data-share-icon-preview]');
+                const select = item.querySelector('[data-share-field="icon"]');
+
+                if (!preview) {
+                    return;
+                }
+
+                const iconKey = select ? select.value : '';
+                const iconSvg = createShareIconPreview(iconKey);
+
+                preview.innerHTML = '';
+
+                if (iconSvg) {
+                    preview.appendChild(iconSvg);
+                }
+            };
+
+            const updateItemNames = () => {
+                const items = Array.from(list.querySelectorAll('[data-share-repeater-item]'));
+
+                items.forEach((item, index) => {
+                    const baseName = `mga_settings[share_channels][${index}]`;
+                    const fields = item.querySelectorAll('[data-share-field]');
+
+                    fields.forEach((field) => {
+                        const fieldKey = field.getAttribute('data-share-field');
+
+                        if (!fieldKey) {
+                            return;
+                        }
+
+                        let effectiveKey = fieldKey;
+
+                        if (fieldKey === 'enabled-hidden') {
+                            effectiveKey = 'enabled';
+                        }
+
+                        field.name = `${baseName}[${effectiveKey}]`;
+                    });
+
+                    applyUid(item);
+                    refreshItemTitle(item);
+                    updateIconPreview(item);
+                });
+            };
+
+            const focusItemField = (item) => {
+                if (!item) {
+                    return;
+                }
+
+                const target = item.querySelector('[data-share-field="label"]') || item;
+                safeFocus(target);
+            };
+
+            list.addEventListener('input', (event) => {
+                const target = event.target;
+
+                if (!target) {
+                    return;
+                }
+
+                const item = target.closest('[data-share-repeater-item]');
+
+                if (!item) {
+                    return;
+                }
+
+                if (target.matches('[data-share-field="label"], [data-share-field="key"]')) {
+                    refreshItemTitle(item);
+                }
+
+                if (target.matches('[data-share-field="icon"]')) {
+                    updateIconPreview(item);
+                }
+            });
+
+            list.addEventListener('change', (event) => {
+                const target = event.target;
+
+                if (!target || !target.matches('[data-share-field="icon"]')) {
+                    return;
+                }
+
+                const item = target.closest('[data-share-repeater-item]');
+
+                if (item) {
+                    updateIconPreview(item);
+                }
+            });
+
+            list.addEventListener('click', (event) => {
+                const button = event.target.closest('[data-share-action]');
+
+                if (!button) {
+                    return;
+                }
+
+                event.preventDefault();
+
+                const action = button.getAttribute('data-share-action');
+                const item = button.closest('[data-share-repeater-item]');
+
+                if (!item) {
+                    return;
+                }
+
+                if (action === 'remove') {
+                    const nextFocusItem = item.nextElementSibling || item.previousElementSibling;
+
+                    if (item.parentNode === list) {
+                        list.removeChild(item);
+                    }
+
+                    updateItemNames();
+
+                    if (nextFocusItem) {
+                        focusItemField(nextFocusItem);
+                    }
+
+                    return;
+                }
+
+                if (action === 'move-up') {
+                    const previous = item.previousElementSibling;
+
+                    if (previous) {
+                        list.insertBefore(item, previous);
+                        updateItemNames();
+                        focusItemField(item);
+                    }
+
+                    return;
+                }
+
+                if (action === 'move-down') {
+                    const next = item.nextElementSibling;
+
+                    if (next) {
+                        list.insertBefore(next, item);
+                        updateItemNames();
+                        focusItemField(item);
+                    }
+                }
+            });
+
+            if (addButton) {
+                addButton.addEventListener('click', (event) => {
+                    event.preventDefault();
+
+                    const fragment = doc.importNode(template.content, true);
+                    const newItem = fragment.querySelector('[data-share-repeater-item]');
+
+                    if (!newItem) {
+                        return;
+                    }
+
+                    list.appendChild(newItem);
+                    updateItemNames();
+                    focusItemField(newItem);
+                });
+            }
+
+            updateItemNames();
         }
     });
 })(typeof window !== 'undefined' ? window : globalThis);

--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -43,6 +43,213 @@
         ? mgaI18n.sprintf
         : fallbackSprintf;
 
+    const SVG_NS = 'http://www.w3.org/2000/svg';
+
+    const SHARE_ICON_LIBRARY = {
+        facebook: {
+            viewBox: '0 0 24 24',
+            paths: [
+                { d: 'M22 12c0-5.52-4.48-10-10-10S2 6.48 2 12c0 4.99 3.66 9.12 8.44 9.88v-6.99H8.08V12h2.36V9.88c0-2.33 1.38-3.62 3.5-3.62 0.72 0 1.48 0.13 1.48 0.13v1.63h-0.83c-0.82 0-1.08 0.51-1.08 1.04V12h1.84l-0.29 1.89h-1.55v6.99C18.34 21.12 22 16.99 22 12z' },
+            ],
+        },
+        twitter: {
+            viewBox: '0 0 24 24',
+            paths: [
+                { d: 'M22.46 6c-0.77 0.35-1.6 0.59-2.46 0.69a4.29 4.29 0 0 0 1.88-2.37 8.59 8.59 0 0 1-2.72 1.04 4.28 4.28 0 0 0-7.3 3.9 12.13 12.13 0 0 1-8.82-4.47 4.28 4.28 0 0 0 1.33 5.72 4.25 4.25 0 0 1-1.94-0.54v0.05a4.28 4.28 0 0 0 3.43 4.2 4.3 4.3 0 0 1-1.93 0.07 4.28 4.28 0 0 0 4 2.97 8.58 8.58 0 0 1-5.3 1.83 12.1 12.1 0 0 0 6.56 1.92c7.88 0 12.2-6.53 12.2-12.2 0-0.19-0.01-0.39-0.01-0.58A8.7 8.7 0 0 0 22.46 6z' },
+            ],
+        },
+        linkedin: {
+            viewBox: '0 0 24 24',
+            paths: [
+                { d: 'M20.45 3H3.55A1.55 1.55 0 0 0 2 4.55v14.9C2 20.3 2.7 21 3.55 21h16.9c0.85 0 1.55-0.7 1.55-1.55V4.55C22 3.7 21.3 3 20.45 3zM8.34 18H5.67V9.67h2.67V18zM7 8.5a1.55 1.55 0 1 1 0-3.1 1.55 1.55 0 0 1 0 3.1zM18.33 18h-2.67v-4.1c0-0.98-0.02-2.24-1.36-2.24-1.36 0-1.56 1.06-1.56 2.16V18h-2.67V9.67h2.56v1.14h0.04c0.36-0.68 1.24-1.4 2.56-1.4 2.74 0 3.25 1.8 3.25 4.13V18z' },
+            ],
+        },
+        pinterest: {
+            viewBox: '0 0 24 24',
+            paths: [
+                { d: 'M12 2C6.48 2 2 6.31 2 11.42c0 3.89 2.68 7.23 6.44 8.41-0.09-0.71-0.17-1.8 0.03-2.58 0.18-0.77 1.15-4.9 1.15-4.9s-0.29-0.58-0.29-1.45c0-1.36 0.79-2.37 1.78-2.37 0.84 0 1.24 0.63 1.24 1.38 0 0.84-0.53 2.09-0.8 3.25-0.23 1 0.5 1.81 1.48 1.81 1.78 0 3.14-1.87 3.14-4.57 0-2.39-1.72-4.07-4.18-4.07-2.85 0-4.52 2.14-4.52 4.35 0 0.86 0.33 1.79 0.74 2.29 0.08 0.1 0.09 0.19 0.07 0.29-0.07 0.31-0.23 1-0.26 1.13-0.04 0.18-0.14 0.22-0.32 0.13-1.2-0.56-1.95-2.29-1.95-3.68 0-3 2.18-5.76 6.29-5.76 3.3 0 5.87 2.35 5.87 5.5 0 3.28-2.06 5.93-4.92 5.93-0.96 0-1.86-0.5-2.17-1.08l-0.59 2.24c-0.21 0.83-0.78 1.87-1.16 2.5 0.87 0.27 1.78 0.42 2.72 0.42 5.52 0 10-4.31 10-9.42C22 6.31 17.52 2 12 2z' },
+            ],
+        },
+        whatsapp: {
+            viewBox: '0 0 24 24',
+            paths: [
+                { d: 'M20.52 3.48A10.5 10.5 0 0 0 2.47 13.3l-1.45 5.28 5.4-1.41A10.5 10.5 0 1 0 20.52 3.48zm-8.5 17.54a8.75 8.75 0 0 1-4.46-1.22l-0.32-0.19-3.21 0.84 0.86-3.13-0.2-0.32a8.75 8.75 0 1 1 7.33 3.99zm4.78-6.53c-0.26-0.13-1.53-0.76-1.77-0.84-0.24-0.09-0.41-0.13-0.58 0.13-0.17 0.26-0.66 0.84-0.8 1.02-0.15 0.17-0.29 0.2-0.55 0.07-0.26-0.13-1.09-0.4-2.07-1.3-0.76-0.68-1.27-1.52-1.42-1.78-0.15-0.26-0.02-0.4 0.11-0.53 0.11-0.11 0.26-0.29 0.39-0.43 0.13-0.15 0.17-0.26 0.26-0.43 0.09-0.17 0.04-0.32-0.02-0.45-0.07-0.13-0.58-1.39-0.8-1.91-0.21-0.5-0.43-0.43-0.58-0.43-0.15 0-0.32-0.02-0.49-0.02-0.17 0-0.43 0.06-0.66 0.32-0.24 0.26-0.89 0.87-0.89 2.13s0.91 2.47 1.03 2.64c0.13 0.17 1.79 2.73 4.34 3.83 0.61 0.26 1.08 0.41 1.45 0.53 0.61 0.19 1.16 0.16 1.6 0.1 0.49-0.07 1.53-0.62 1.75-1.22 0.21-0.6 0.21-1.11 0.15-1.22-0.06-0.1-0.24-0.16-0.5-0.29z' },
+            ],
+        },
+        telegram: {
+            viewBox: '0 0 24 24',
+            paths: [
+                { d: 'M21.5 2.5l-19 7.5c-1.3 0.52-1.29 2.35 0.02 2.85l4.8 1.9 1.9 4.8c0.5 1.31 2.34 1.32 2.85 0.02l7.5-19c0.42-1.06-0.64-2.12-1.67-1.67zM10 14l-1 4-1.5-3.8 8.3-6.2-5.8 6z' },
+            ],
+        },
+        email: {
+            viewBox: '0 0 24 24',
+            paths: [
+                { d: 'M20 4H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2zm0 2-8 5-8-5h16zm0 12H4V8l8 5 8-5v10z' },
+            ],
+        },
+        link: {
+            viewBox: '0 0 24 24',
+            paths: [
+                { d: 'M10.59 13.41a1 1 0 0 1 0-1.41l2-2a1 1 0 1 1 1.41 1.41l-2 2a1 1 0 0 1-1.41 0zm-2.83 2.83a3 3 0 0 1 0-4.24l2-2a3 3 0 0 1 4.24 0 1 1 0 0 1-1.41 1.41 1 1 0 0 0-1.41 0l-2 2a1 1 0 0 0 0 1.41 1 1 0 0 0 1.41 0l1-1a1 1 0 1 1 1.41 1.41l-1 1a3 3 0 0 1-4.24 0zm8.48-8.48a3 3 0 0 0-4.24 0l-1 1a1 1 0 0 1-1.41-1.41l1-1a5 5 0 1 1 7.07 7.07l-2 2a5 5 0 0 1-7.07 0 1 1 0 0 1 1.41-1.41 3 3 0 0 0 4.24 0l2-2a3 3 0 0 0 0-4.24z' },
+            ],
+        },
+        copy: {
+            viewBox: '0 0 24 24',
+            paths: [
+                { d: 'M16 1H4a2 2 0 0 0-2 2v12h2V3h12V1zm3 4H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm0 16H8V7h11v14z' },
+            ],
+        },
+        download: {
+            viewBox: '0 0 24 24',
+            paths: [
+                { d: 'M5 20h14v-2H5v2zm7-16v9l3.5-3.5 1.42 1.42L12 17l-4.92-4.92L8.5 10.66 12 14.17V4z' },
+            ],
+        },
+        native: {
+            viewBox: '0 0 24 24',
+            paths: [
+                { d: 'M18 16.08c-0.76 0-1.44 0.3-1.96 0.77L8.91 12.7c0.05-0.23 0.09-0.46 0.09-0.7s-0.04-0.47-0.09-0.7l7.02-4.11A2.99 2.99 0 0 0 18 7.91c1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 0.24 0.03 0.47 0.09 0.7L8.07 9.7A2.99 2.99 0 0 0 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c0.79 0 1.5-0.31 2.03-0.82l7.05 4.12c-0.06 0.23-0.08 0.46-0.08 0.7 0 1.65 1.34 2.99 3 2.99s3-1.34 3-2.99-1.34-3-3-3z' },
+            ],
+        },
+        generic: {
+            viewBox: '0 0 24 24',
+            paths: [
+                { d: 'M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2z' },
+                { d: 'M13 17h-2v-2h2zm0-4h-2V7h2z' },
+            ],
+        },
+    };
+
+    const sanitizeIconKey = (value) => {
+        if (typeof value !== 'string') {
+            return '';
+        }
+
+        return value.trim().toLowerCase().replace(/[^a-z0-9_-]/g, '');
+    };
+
+    const createSvgElement = (tag, attributes = {}) => {
+        const element = document.createElementNS(SVG_NS, tag);
+
+        Object.keys(attributes).forEach((attribute) => {
+            element.setAttribute(attribute, attributes[attribute]);
+        });
+
+        return element;
+    };
+
+    const createShareIconElement = (iconKey) => {
+        const sanitizedKey = sanitizeIconKey(iconKey);
+        const definition = SHARE_ICON_LIBRARY[sanitizedKey] || SHARE_ICON_LIBRARY.generic;
+        const wrapper = document.createElement('span');
+        wrapper.className = 'mga-share-option__icon';
+
+        const svg = createSvgElement('svg', {
+            viewBox: definition.viewBox,
+            fill: 'currentColor',
+            'aria-hidden': 'true',
+            focusable: 'false',
+        });
+
+        if (Array.isArray(definition.paths)) {
+            definition.paths.forEach((pathDefinition) => {
+                const path = createSvgElement('path', pathDefinition);
+
+                if (path) {
+                    svg.appendChild(path);
+                }
+            });
+        }
+
+        wrapper.appendChild(svg);
+
+        return wrapper;
+    };
+
+    const SHARE_CHANNEL_LABELS = {
+        facebook: mga__( 'Facebook', 'lightbox-jlg' ),
+        twitter: mga__( 'Twitter', 'lightbox-jlg' ),
+        linkedin: mga__( 'LinkedIn', 'lightbox-jlg' ),
+        pinterest: mga__( 'Pinterest', 'lightbox-jlg' ),
+        whatsapp: mga__( 'WhatsApp', 'lightbox-jlg' ),
+        telegram: mga__( 'Telegram', 'lightbox-jlg' ),
+        email: mga__( 'E-mail', 'lightbox-jlg' ),
+        link: mga__( 'Lien', 'lightbox-jlg' ),
+    };
+
+    function normalizeShareChannels(rawChannels) {
+        const entries = [];
+
+        if (Array.isArray(rawChannels)) {
+            rawChannels.forEach((channel) => {
+                entries.push(channel);
+            });
+        } else if (rawChannels && typeof rawChannels === 'object') {
+            Object.keys(rawChannels).forEach((key) => {
+                const candidate = rawChannels[key];
+
+                if (candidate && typeof candidate === 'object') {
+                    entries.push(Object.assign({ key }, candidate));
+                }
+            });
+        }
+
+        const seenKeys = new Set();
+
+        return entries.reduce((accumulator, entry) => {
+            if (!entry || typeof entry !== 'object') {
+                return accumulator;
+            }
+
+            let rawKey = '';
+
+            if (typeof entry.key === 'string') {
+                rawKey = entry.key;
+            } else if (typeof entry.slug === 'string') {
+                rawKey = entry.slug;
+            }
+
+            let key = sanitizeIconKey(rawKey);
+
+            if (!key && typeof entry.label === 'string') {
+                key = sanitizeIconKey(entry.label.replace(/\s+/g, '-'));
+            }
+
+            if (!key || seenKeys.has(key)) {
+                return accumulator;
+            }
+
+            seenKeys.add(key);
+
+            const label = typeof entry.label === 'string' && entry.label.trim()
+                ? entry.label.trim()
+                : (SHARE_CHANNEL_LABELS[key] || key.charAt(0).toUpperCase() + key.slice(1));
+
+            const template = typeof entry.template === 'string'
+                ? entry.template.trim()
+                : '';
+
+            const icon = sanitizeIconKey(entry.icon || key) || key;
+
+            const enabled = entry.enabled === true
+                || entry.enabled === '1'
+                || entry.enabled === 1
+                || entry.enabled === 'true'
+                || entry.enabled === 'on';
+
+            accumulator.push({
+                key,
+                label,
+                template,
+                icon,
+                enabled,
+            });
+
+            return accumulator;
+        }, []);
+    }
+
     const DEFAULT_EFFECT = 'slide';
     const DEFAULT_SPEED = 600;
     const DEFAULT_EASING = 'ease-out';
@@ -184,15 +391,7 @@
         const showThumbsMobile = normalizeFlag(settings.show_thumbs_mobile, true);
         const shareCopyEnabled = normalizeFlag(settings.share_copy, true);
         const shareDownloadEnabled = normalizeFlag(settings.share_download, true);
-        const shareChannels = settings.share_channels && typeof settings.share_channels === 'object'
-            ? settings.share_channels
-            : {};
-        const shareTargetLabels = {
-            facebook: mga__( 'Facebook', 'lightbox-jlg' ),
-            twitter: mga__( 'Twitter', 'lightbox-jlg' ),
-            linkedin: mga__( 'LinkedIn', 'lightbox-jlg' ),
-            pinterest: mga__( 'Pinterest', 'lightbox-jlg' ),
-        };
+        const shareChannels = normalizeShareChannels(settings.share_channels);
         const shareActionLabels = {
             copy: mga__( 'Copier le lien', 'lightbox-jlg' ),
             download: mga__( 'Téléchargement rapide', 'lightbox-jlg' ),
@@ -563,7 +762,32 @@
                     button.setAttribute('data-share-template', option.template);
                 }
 
-                button.textContent = option.label;
+                if (option.icon) {
+                    button.setAttribute('data-share-icon', option.icon);
+                }
+
+                const content = document.createElement('span');
+                content.className = 'mga-share-option__content';
+
+                const iconElement = createShareIconElement(option.icon);
+
+                if (iconElement) {
+                    content.appendChild(iconElement);
+                }
+
+                const labelSpan = document.createElement('span');
+                labelSpan.className = 'mga-share-option__label';
+                labelSpan.textContent = option.label;
+                content.appendChild(labelSpan);
+
+                button.appendChild(content);
+
+                const chevron = document.createElement('span');
+                chevron.className = 'mga-share-option__chevron';
+                chevron.setAttribute('aria-hidden', 'true');
+                chevron.textContent = '›';
+                button.appendChild(chevron);
+
                 item.appendChild(button);
                 modalInstance.list.appendChild(item);
             });
@@ -572,27 +796,24 @@
         function buildShareOptions(sharePayload) {
             const options = [];
 
-            Object.keys(shareChannels).forEach((channelKey) => {
-                const config = shareChannels[channelKey];
-
-                if (!config || typeof config !== 'object') {
+            shareChannels.forEach((channel) => {
+                if (!channel || typeof channel !== 'object') {
                     return;
                 }
 
-                const enabled = typeof config.enabled === 'boolean' ? config.enabled : Boolean(config.enabled);
-                const template = typeof config.template === 'string' ? config.template.trim() : '';
+                const { enabled, template } = channel;
+                const hasTemplate = typeof template === 'string' && template.trim() !== '';
 
-                if (!enabled || !template) {
+                if (!enabled || !hasTemplate) {
                     return;
                 }
-
-                const label = shareTargetLabels[channelKey] || channelKey;
 
                 options.push({
                     type: 'social',
-                    key: channelKey,
-                    label,
-                    template,
+                    key: channel.key,
+                    label: channel.label || SHARE_CHANNEL_LABELS[channel.key] || channel.key,
+                    template: template.trim(),
+                    icon: channel.icon || channel.key,
                 });
             });
 
@@ -601,6 +822,7 @@
                     type: 'copy',
                     key: 'copy',
                     label: shareActionLabels.copy,
+                    icon: 'copy',
                 });
             }
 
@@ -609,6 +831,7 @@
                     type: 'download',
                     key: 'download',
                     label: shareActionLabels.download,
+                    icon: 'download',
                 });
             }
 
@@ -617,6 +840,7 @@
                     type: 'native',
                     key: 'native',
                     label: shareActionLabels.native,
+                    icon: 'native',
                 });
             }
 
@@ -1458,15 +1682,6 @@
             let viewer = document.getElementById('mga-viewer');
             if (!viewer) {
                 debug.log(mga__( 'Viewer non trouvé. Création à la volée...', 'lightbox-jlg' ));
-
-                const SVG_NS = 'http://www.w3.org/2000/svg';
-                const createSvgElement = (tag, attributes = {}) => {
-                    const element = document.createElementNS(SVG_NS, tag);
-                    Object.keys(attributes).forEach(attr => {
-                        element.setAttribute(attr, attributes[attr]);
-                    });
-                    return element;
-                };
 
                 viewer = document.createElement('div');
                 viewer.id = 'mga-viewer';


### PR DESCRIPTION
## Summary
- autoriser une liste dynamique de canaux de partage côté paramètres et UI d’administration
- mettre à jour la modale de partage pour générer les options et icônes depuis cette liste normalisée
- ajuster les styles afin d’intégrer le répéteur et les nouvelles icônes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68def9c967a4832e899c196ff59cfa3b