### PR TITLE
Generalize share channels configuration

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -129,6 +129,19 @@
         return value.trim().toLowerCase().replace(/[^a-z0-9_-]/g, '');
     };
 
+    const buildLabelFromKey = (key) => {
+        if (typeof key !== 'string' || key.trim() === '') {
+            return '';
+        }
+
+        return key
+            .trim()
+            .split(/[-_\s]+/)
+            .filter(Boolean)
+            .map((chunk) => chunk.charAt(0).toUpperCase() + chunk.slice(1))
+            .join(' ');
+    };
+
     const createSvgElement = (tag, attributes = {}) => {
         const element = document.createElementNS(SVG_NS, tag);
 
@@ -165,17 +178,6 @@
         wrapper.appendChild(svg);
 
         return wrapper;
-    };
-
-    const SHARE_CHANNEL_LABELS = {
-        facebook: mga__( 'Facebook', 'lightbox-jlg' ),
-        twitter: mga__( 'Twitter', 'lightbox-jlg' ),
-        linkedin: mga__( 'LinkedIn', 'lightbox-jlg' ),
-        pinterest: mga__( 'Pinterest', 'lightbox-jlg' ),
-        whatsapp: mga__( 'WhatsApp', 'lightbox-jlg' ),
-        telegram: mga__( 'Telegram', 'lightbox-jlg' ),
-        email: mga__( 'E-mail', 'lightbox-jlg' ),
-        link: mga__( 'Lien', 'lightbox-jlg' ),
     };
 
     function normalizeShareChannels(rawChannels) {
@@ -224,7 +226,7 @@
 
             const label = typeof entry.label === 'string' && entry.label.trim()
                 ? entry.label.trim()
-                : (SHARE_CHANNEL_LABELS[key] || key.charAt(0).toUpperCase() + key.slice(1));
+                : buildLabelFromKey(key);
 
             const template = typeof entry.template === 'string'
                 ? entry.template.trim()
@@ -811,7 +813,7 @@
                 options.push({
                     type: 'social',
                     key: channel.key,
-                    label: channel.label || SHARE_CHANNEL_LABELS[channel.key] || channel.key,
+                    label: channel.label || buildLabelFromKey(channel.key) || channel.key,
                     template: template.trim(),
                     icon: channel.icon || channel.key,
                 });

--- a/ma-galerie-automatique/includes/admin-page-template.php
+++ b/ma-galerie-automatique/includes/admin-page-template.php
@@ -286,22 +286,18 @@ $settings          = wp_parse_args( $sanitized_settings, $defaults );
                     <th scope="row"><?php echo esc_html__( 'Canaux de partage', 'lightbox-jlg' ); ?></th>
                     <td>
                         <?php
-                        $share_channels = isset( $settings['share_channels'] ) && is_array( $settings['share_channels'] )
+                        $share_channels     = isset( $settings['share_channels'] ) && is_array( $settings['share_channels'] )
                             ? array_values( $settings['share_channels'] )
                             : [];
-                        $share_icon_choices = [
-                            'facebook'  => __( 'Facebook', 'lightbox-jlg' ),
-                            'twitter'   => __( 'Twitter', 'lightbox-jlg' ),
-                            'linkedin'  => __( 'LinkedIn', 'lightbox-jlg' ),
-                            'pinterest' => __( 'Pinterest', 'lightbox-jlg' ),
-                            'whatsapp'  => __( 'WhatsApp', 'lightbox-jlg' ),
-                            'telegram'  => __( 'Telegram', 'lightbox-jlg' ),
-                            'email'     => __( 'E-mail', 'lightbox-jlg' ),
-                            'link'      => __( 'Lien', 'lightbox-jlg' ),
-                            'generic'   => __( 'Icône générique', 'lightbox-jlg' ),
-                        ];
+                        $share_icon_choices = mga_get_share_icon_choices();
                         $render_icon_options = static function ( array $choices, string $selected ): string {
                             $options = '';
+
+                            if ( '' !== $selected && ! array_key_exists( $selected, $choices ) ) {
+                                $choices = [
+                                    $selected => ucwords( str_replace( [ '-', '_' ], ' ', $selected ) ),
+                                ] + $choices;
+                            }
 
                             foreach ( $choices as $value => $label ) {
                                 $options .= sprintf(

--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -211,6 +211,18 @@ function mga_get_default_settings(): array {
     return $plugin ? $plugin->settings()->get_default_settings() : [];
 }
 
+function mga_get_share_channel_catalog(): array {
+    $plugin = mga_plugin();
+
+    return $plugin ? $plugin->settings()->get_share_channel_catalog() : [];
+}
+
+function mga_get_share_icon_choices(): array {
+    $plugin = mga_plugin();
+
+    return $plugin ? $plugin->settings()->get_share_icon_choices() : [];
+}
+
 function mga_sanitize_settings( $input, $existing_settings = null ): array {
     $plugin = mga_plugin();
 


### PR DESCRIPTION
## Summary
- expose a share channel catalog and icon list so new networks can be registered via filters while keeping defaults up to date
- update the admin repeater to use the dynamic icon list and preserve unknown selections when reordering or duplicating
- adjust the frontend slideshow to label options dynamically and render any number of share buttons based on the sanitized settings

## Testing
- php -l ma-galerie-automatique/includes/Admin/Settings.php
- php -l ma-galerie-automatique/includes/admin-page-template.php
- php -l ma-galerie-automatique/ma-galerie-automatique.php

------
https://chatgpt.com/codex/tasks/task_e_68df9639a700832e962d7671f8bd1edd