### PR TITLE
Prevent share modal interactions from closing viewer

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -686,7 +686,12 @@
             dialog.setAttribute('aria-describedby', description.id);
             viewer.appendChild(modalContainer);
 
-            const onOverlayClick = () => closeShareModal({ reason: 'overlay' });
+            const onOverlayClick = (event) => {
+                if (event && typeof event.stopPropagation === 'function') {
+                    event.stopPropagation();
+                }
+                closeShareModal({ reason: 'overlay' });
+            };
             const onCloseClick = () => closeShareModal({ reason: 'close-button' });
 
             overlay.addEventListener('click', onOverlayClick);
@@ -2900,9 +2905,14 @@
                 return;
             }
             const clickedInsideViewer = viewer.contains(eventTarget);
+            const clickedInsideShareModal = Boolean(eventTarget.closest('.mga-share-modal'));
             const clickedInsideMainSwiper = Boolean(eventTarget.closest('.mga-main-swiper'));
             const clickedInsideHeader = Boolean(eventTarget.closest('.mga-header'));
             const clickedInsideThumbs = Boolean(eventTarget.closest('.mga-thumbs-swiper'));
+
+            if (clickedInsideShareModal) {
+                return;
+            }
 
             if (
                 eventTarget === viewer ||


### PR DESCRIPTION
## Summary
- stop propagation when clicking the share modal overlay so the viewer stays open
- ignore clicks occurring inside the share modal in the global body handler

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfc1b4ab9c832ebb8d477bce1da861