### PR TITLE
Improve accessibility of lightbox editor note

### DIFF
--- a/ma-galerie-automatique/assets/css/block-editor-preview.css
+++ b/ma-galerie-automatique/assets/css/block-editor-preview.css
@@ -35,6 +35,19 @@
     pointer-events: none;
 }
 
+.block-editor-block-list__layout .mga-screen-reader-text {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+}
+
 .block-editor-block-list__layout a.mga-editor-preview__link {
     position: relative;
     border-radius: 8px;

--- a/ma-galerie-automatique/assets/css/block/editor.css
+++ b/ma-galerie-automatique/assets/css/block/editor.css
@@ -233,6 +233,8 @@
     border: 0;
     overflow: hidden;
     clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
 }
 
 @media (max-width: 782px) {

--- a/ma-galerie-automatique/assets/js/block-editor-preview.js
+++ b/ma-galerie-automatique/assets/js/block-editor-preview.js
@@ -140,8 +140,20 @@
             var extraClass = 'mga-editor-preview--lightbox';
             var mergedClassName = classnames( props.className, extraClass );
             var wrapperProps = props.wrapperProps ? Object.assign( {}, props.wrapperProps ) : {};
+            var descriptionId = null;
+
+            if ( props.block && props.block.name === previewBlockName && props.block.clientId ) {
+                descriptionId = 'mga-lightbox-note-' + props.block.clientId;
+            }
+
             wrapperProps.className = classnames( wrapperProps.className, extraClass );
             wrapperProps[ 'data-mga-lightbox-note' ] = noteText;
+
+            if ( descriptionId ) {
+                wrapperProps[ 'aria-describedby' ] = descriptionId;
+            } else if ( ! wrapperProps[ 'aria-label' ] ) {
+                wrapperProps[ 'aria-label' ] = noteText;
+            }
 
             var enhancedProps = Object.assign( {}, props, {
                 className: mergedClassName,

--- a/ma-galerie-automatique/assets/js/block/index.js
+++ b/ma-galerie-automatique/assets/js/block/index.js
@@ -359,6 +359,7 @@
         var blockProps = useBlockProps( {
             className: 'mga-block-preview mga-editor-preview--lightbox'
         } );
+        var hiddenNoteId = props.clientId ? 'mga-lightbox-note-' + props.clientId : null;
 
         if ( blockProps.className ) {
             blockProps.className += ' mga-block-preview--block';
@@ -367,6 +368,12 @@
         }
 
         blockProps[ 'data-mga-lightbox-note' ] = noteText;
+
+        if ( hiddenNoteId ) {
+            blockProps[ 'aria-describedby' ] = hiddenNoteId;
+        } else if ( ! blockProps[ 'aria-label' ] ) {
+            blockProps[ 'aria-label' ] = noteText;
+        }
 
         function onToggle( key ) {
             return function( value ) {
@@ -549,6 +556,7 @@
             el(
                 'div',
                 blockProps,
+                el( 'span', { className: 'mga-screen-reader-text', id: hiddenNoteId || undefined }, noteText ),
                 el( Preview, { attributes: attributes } )
             )
         );


### PR DESCRIPTION
## Summary
- expose the lightbox badge text via accessible attributes when decorating supported blocks
- add a dedicated screen-reader span to the lightbox preview block so the badge message is announced
- keep the screen-reader text visually hidden in editor previews while remaining available to assistive tech

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dff7f21e20832e9a86480e9b1bae2e