### PR TITLE
Expose sanitized block settings to the block editor

### DIFF
--- a/ma-galerie-automatique/assets/js/block/index.js
+++ b/ma-galerie-automatique/assets/js/block/index.js
@@ -1,4 +1,4 @@
-/* global mgaBlockDefaults */
+/* global mgaBlockDefaults, mgaBlockSettings */
 ( function() {
     'use strict';
 
@@ -46,9 +46,18 @@
     var data = wp.data || {};
     var useSelect = typeof data.useSelect === 'function' ? data.useSelect : null;
 
-    var defaults = root.mgaBlockDefaults || {};
+    var defaults = root.mgaBlockDefaults && typeof root.mgaBlockDefaults === 'object'
+        ? root.mgaBlockDefaults
+        : {};
+    var currentSettings = root.mgaBlockSettings && typeof root.mgaBlockSettings === 'object'
+        ? root.mgaBlockSettings
+        : null;
 
-    function getDefault( key, fallback ) {
+    function getConfigValue( key, fallback ) {
+        if ( currentSettings && Object.prototype.hasOwnProperty.call( currentSettings, key ) ) {
+            return currentSettings[ key ];
+        }
+
         if ( Object.prototype.hasOwnProperty.call( defaults, key ) ) {
             return defaults[ key ];
         }
@@ -56,21 +65,21 @@
         return fallback;
     }
 
-    var defaultAccent = getDefault( 'accentColor', '#ffffff' );
-    var defaultBackgroundStyle = getDefault( 'backgroundStyle', 'echo' );
-    var defaultAutoplay = !! getDefault( 'autoplay', false );
-    var defaultLoop = !! getDefault( 'loop', true );
-    var defaultDelay = parseInt( getDefault( 'delay', 4 ), 10 ) || 4;
-    var defaultBgOpacity = parseFloat( getDefault( 'bgOpacity', 0.95 ) ) || 0.95;
-    var defaultSpeed = parseInt( getDefault( 'speed', 600 ), 10 ) || 600;
-    var defaultEffect = getDefault( 'effect', 'slide' );
-    var defaultEasing = getDefault( 'easing', 'ease-out' );
-    var defaultThumbsMobile = !! getDefault( 'showThumbsMobile', true );
-    var defaultZoom = !! getDefault( 'showZoom', true );
-    var defaultDownload = !! getDefault( 'showDownload', true );
-    var defaultShare = !! getDefault( 'showShare', true );
-    var defaultFullscreen = !! getDefault( 'showFullscreen', true );
-    var noteText = getDefault( 'noteText', __( 'Lightbox active', 'lightbox-jlg' ) );
+    var defaultAccent = getConfigValue( 'accentColor', '#ffffff' );
+    var defaultBackgroundStyle = getConfigValue( 'backgroundStyle', 'echo' );
+    var defaultAutoplay = !! getConfigValue( 'autoplay', false );
+    var defaultLoop = !! getConfigValue( 'loop', true );
+    var defaultDelay = parseInt( getConfigValue( 'delay', 4 ), 10 ) || 4;
+    var defaultBgOpacity = parseFloat( getConfigValue( 'bgOpacity', 0.95 ) ) || 0.95;
+    var defaultSpeed = parseInt( getConfigValue( 'speed', 600 ), 10 ) || 600;
+    var defaultEffect = getConfigValue( 'effect', 'slide' );
+    var defaultEasing = getConfigValue( 'easing', 'ease-out' );
+    var defaultThumbsMobile = !! getConfigValue( 'showThumbsMobile', true );
+    var defaultZoom = !! getConfigValue( 'showZoom', true );
+    var defaultDownload = !! getConfigValue( 'showDownload', true );
+    var defaultShare = !! getConfigValue( 'showShare', true );
+    var defaultFullscreen = !! getConfigValue( 'showFullscreen', true );
+    var noteText = getConfigValue( 'noteText', __( 'Lightbox active', 'lightbox-jlg' ) );
 
     var PLACEHOLDER_IMAGES = [
         { color: '#3148a5', label: __( 'Montagnes', 'lightbox-jlg' ) },

--- a/ma-galerie-automatique/includes/Frontend/Assets.php
+++ b/ma-galerie-automatique/includes/Frontend/Assets.php
@@ -236,6 +236,11 @@ class Assets {
             true
         );
 
+        $merged_settings   = wp_parse_args( $settings, $defaults );
+        $block_localization = $this->plugin->prepare_block_settings( $merged_settings );
+
+        wp_localize_script( 'mga-lightbox-editor-block', 'mgaBlockSettings', $block_localization );
+
         $localization = [
             'noteText'        => \__( 'Lightbox active', 'lightbox-jlg' ),
             'supportedBlocks' => $allowed_block_names,

--- a/ma-galerie-automatique/includes/Plugin.php
+++ b/ma-galerie-automatique/includes/Plugin.php
@@ -171,26 +171,17 @@ class Plugin {
         );
 
         $defaults = $this->settings->get_default_settings();
+        $block_defaults = $this->prepare_block_settings( $defaults );
 
-        $localization = [
-            'accentColor'      => $defaults['accent_color'] ?? '#ffffff',
-            'backgroundStyle'  => $defaults['background_style'] ?? 'echo',
-            'autoplay'         => (bool) ( $defaults['autoplay_start'] ?? false ),
-            'loop'             => (bool) ( $defaults['loop'] ?? true ),
-            'delay'            => (int) ( $defaults['delay'] ?? 4 ),
-            'speed'            => (int) ( $defaults['speed'] ?? 600 ),
-            'effect'           => $defaults['effect'] ?? 'slide',
-            'easing'           => $defaults['easing'] ?? 'ease-out',
-            'bgOpacity'        => isset( $defaults['bg_opacity'] ) ? (float) $defaults['bg_opacity'] : 0.95,
-            'showThumbsMobile' => (bool) ( $defaults['show_thumbs_mobile'] ?? true ),
-            'showZoom'         => (bool) ( $defaults['show_zoom'] ?? true ),
-            'showDownload'     => (bool) ( $defaults['show_download'] ?? true ),
-            'showShare'        => (bool) ( $defaults['show_share'] ?? true ),
-            'showFullscreen'   => (bool) ( $defaults['show_fullscreen'] ?? true ),
-            'noteText'         => \__( 'Lightbox active', 'lightbox-jlg' ),
-        ];
+        $block_defaults_json = wp_json_encode( $block_defaults );
 
-        wp_localize_script( $script_handle, 'mgaBlockDefaults', $localization );
+        if ( false !== $block_defaults_json ) {
+            wp_add_inline_script(
+                $script_handle,
+                'window.mgaBlockDefaults = window.mgaBlockDefaults || ' . $block_defaults_json . ';',
+                'before'
+            );
+        }
 
         if ( $this->languages_directory_exists() ) {
             wp_set_script_translations( $script_handle, 'lightbox-jlg', $this->get_languages_path() );
@@ -204,5 +195,31 @@ class Plugin {
                 'render_callback' => '__return_empty_string',
             ]
         );
+    }
+
+    public function prepare_block_settings( array $settings ): array {
+        $accent_color = isset( $settings['accent_color'] ) ? sanitize_hex_color( $settings['accent_color'] ) : null;
+
+        if ( ! $accent_color ) {
+            $accent_color = '#ffffff';
+        }
+
+        return [
+            'accentColor'      => $accent_color,
+            'backgroundStyle'  => isset( $settings['background_style'] ) ? (string) $settings['background_style'] : 'echo',
+            'autoplay'         => ! empty( $settings['autoplay_start'] ),
+            'loop'             => isset( $settings['loop'] ) ? (bool) $settings['loop'] : true,
+            'delay'            => isset( $settings['delay'] ) ? (int) $settings['delay'] : 4,
+            'speed'            => isset( $settings['speed'] ) ? (int) $settings['speed'] : 600,
+            'effect'           => isset( $settings['effect'] ) ? (string) $settings['effect'] : 'slide',
+            'easing'           => isset( $settings['easing'] ) ? (string) $settings['easing'] : 'ease-out',
+            'bgOpacity'        => isset( $settings['bg_opacity'] ) ? (float) $settings['bg_opacity'] : 0.95,
+            'showThumbsMobile' => ! empty( $settings['show_thumbs_mobile'] ),
+            'showZoom'         => ! empty( $settings['show_zoom'] ),
+            'showDownload'     => ! empty( $settings['show_download'] ),
+            'showShare'        => ! empty( $settings['show_share'] ),
+            'showFullscreen'   => ! empty( $settings['show_fullscreen'] ),
+            'noteText'         => __( 'Lightbox active', 'lightbox-jlg' ),
+        ];
     }
 }


### PR DESCRIPTION
## Summary
- expose sanitized plugin settings to the block editor script using the same structure as existing defaults
- ensure default localization no longer overwrites configured values and centralize block payload formatting
- initialize the block editor script with current settings before falling back to defaults so inspector controls show saved values

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dff7f29d84832eb9ff56e6a90d7f2f