### PR TITLE
Expose les réglages sanitisés du bloc dans l’éditeur

### DIFF
--- a/ma-galerie-automatique/assets/js/block/index.js
+++ b/ma-galerie-automatique/assets/js/block/index.js
@@ -49,17 +49,34 @@
     var defaults = root.mgaBlockDefaults && typeof root.mgaBlockDefaults === 'object'
         ? root.mgaBlockDefaults
         : {};
-    var currentSettings = root.mgaBlockSettings && typeof root.mgaBlockSettings === 'object'
+    var savedSettings = root.mgaBlockSettings && typeof root.mgaBlockSettings === 'object'
         ? root.mgaBlockSettings
         : null;
 
+    var effectiveSettings = {};
+    var key;
+
+    for ( key in defaults ) {
+        if ( Object.prototype.hasOwnProperty.call( defaults, key ) ) {
+            effectiveSettings[ key ] = defaults[ key ];
+        }
+    }
+
+    if ( savedSettings ) {
+        for ( key in savedSettings ) {
+            if ( Object.prototype.hasOwnProperty.call( savedSettings, key ) ) {
+                effectiveSettings[ key ] = savedSettings[ key ];
+            }
+        }
+    }
+
     function getConfigValue( key, fallback ) {
-        if ( currentSettings && Object.prototype.hasOwnProperty.call( currentSettings, key ) ) {
-            return currentSettings[ key ];
+        if ( savedSettings && Object.prototype.hasOwnProperty.call( savedSettings, key ) ) {
+            return savedSettings[ key ];
         }
 
-        if ( Object.prototype.hasOwnProperty.call( defaults, key ) ) {
-            return defaults[ key ];
+        if ( Object.prototype.hasOwnProperty.call( effectiveSettings, key ) ) {
+            return effectiveSettings[ key ];
         }
 
         return fallback;

--- a/ma-galerie-automatique/includes/Frontend/Assets.php
+++ b/ma-galerie-automatique/includes/Frontend/Assets.php
@@ -236,10 +236,27 @@ class Assets {
             true
         );
 
-        $merged_settings   = wp_parse_args( $settings, $defaults );
-        $block_localization = $this->plugin->prepare_block_settings( $merged_settings );
+        $merged_settings = wp_parse_args( $settings, $defaults );
+        $block_settings  = $this->plugin->prepare_block_settings( $merged_settings );
 
-        wp_localize_script( 'mga-lightbox-editor-block', 'mgaBlockSettings', $block_localization );
+        $block_settings_json = wp_json_encode( $block_settings );
+
+        if ( false !== $block_settings_json ) {
+            $inline_settings = sprintf(
+                '( function() {' .
+                ' var defaults = ( window.mgaBlockDefaults && typeof window.mgaBlockDefaults === "object" ) ? window.mgaBlockDefaults : {};' .
+                ' var overrides = %1$s;' .
+                ' var merged = {};' .
+                ' var key;' .
+                ' for ( key in defaults ) { if ( Object.prototype.hasOwnProperty.call( defaults, key ) ) { merged[ key ] = defaults[ key ]; } }' .
+                ' for ( key in overrides ) { if ( Object.prototype.hasOwnProperty.call( overrides, key ) ) { merged[ key ] = overrides[ key ]; } }' .
+                ' window.mgaBlockSettings = merged;' .
+                '} )();',
+                $block_settings_json
+            );
+
+            wp_add_inline_script( 'mga-lightbox-editor-block', $inline_settings, 'before' );
+        }
 
         $localization = [
             'noteText'        => \__( 'Lightbox active', 'lightbox-jlg' ),

--- a/ma-galerie-automatique/includes/Plugin.php
+++ b/ma-galerie-automatique/includes/Plugin.php
@@ -170,17 +170,29 @@ class Plugin {
             MGA_VERSION
         );
 
-        $defaults = $this->settings->get_default_settings();
+        $defaults          = $this->settings->get_default_settings();
+        $sanitized_settings = $this->settings->get_sanitized_settings();
+        $merged_settings    = wp_parse_args( $sanitized_settings, $defaults );
+
         $block_defaults = $this->prepare_block_settings( $defaults );
+        $block_settings = $this->prepare_block_settings( $merged_settings );
+
+        $inline_chunks = [];
 
         $block_defaults_json = wp_json_encode( $block_defaults );
 
         if ( false !== $block_defaults_json ) {
-            wp_add_inline_script(
-                $script_handle,
-                'window.mgaBlockDefaults = window.mgaBlockDefaults || ' . $block_defaults_json . ';',
-                'before'
-            );
+            $inline_chunks[] = 'window.mgaBlockDefaults = window.mgaBlockDefaults || ' . $block_defaults_json . ';';
+        }
+
+        $block_settings_json = wp_json_encode( $block_settings );
+
+        if ( false !== $block_settings_json ) {
+            $inline_chunks[] = 'window.mgaBlockSettings = window.mgaBlockSettings || ' . $block_settings_json . ';';
+        }
+
+        if ( ! empty( $inline_chunks ) ) {
+            wp_add_inline_script( $script_handle, implode( '', $inline_chunks ), 'before' );
         }
 
         if ( $this->languages_directory_exists() ) {


### PR DESCRIPTION
## Summary
- injecte les réglages sanitisés dans les scripts du bloc en réutilisant la structure des defaults
- fusionne defaults et réglages sauvegardés lors de l’enregistrement du bloc pour éviter qu’ils soient écrasés
- met à jour l’initialisation du bloc côté JS pour privilégier les réglages actifs et ne retomber sur les defaults qu’en dernier recours

## Testing
- php -l ma-galerie-automatique/includes/Frontend/Assets.php
- php -l ma-galerie-automatique/includes/Plugin.php

------
https://chatgpt.com/codex/tasks/task_e_68e034b9f8d0832e9e3ee0472a214818