### PR TITLE
Add backdrop click toggle for viewer

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -391,6 +391,7 @@
         let showShare = normalizeFlag(settings.show_share, true);
         const showFullscreen = normalizeFlag(settings.show_fullscreen, true);
         const showThumbsMobile = normalizeFlag(settings.show_thumbs_mobile, true);
+        const closeOnBackdropClick = normalizeFlag(settings.close_on_backdrop, true);
         let shareCopyEnabled = normalizeFlag(settings.share_copy, true);
         let shareDownloadEnabled = normalizeFlag(settings.share_download, true);
         let shareChannels = normalizeShareChannels(settings.share_channels);
@@ -3025,7 +3026,9 @@
                 eventTarget === viewer ||
                 (clickedInsideViewer && !clickedInsideMainSwiper && !clickedInsideHeader && !clickedInsideThumbs)
             ) {
-                closeViewer(viewer);
+                if (closeOnBackdropClick) {
+                    closeViewer(viewer);
+                }
                 return;
             }
             if (eventTarget.closest('#mga-close')) {

--- a/ma-galerie-automatique/includes/Admin/Settings.php
+++ b/ma-galerie-automatique/includes/Admin/Settings.php
@@ -268,6 +268,7 @@ class Settings {
             'show_download'      => true,
             'show_share'         => true,
             'show_fullscreen'    => true,
+            'close_on_backdrop'  => true,
             'show_thumbs_mobile' => true,
             'share_channels'     => $this->get_default_share_channels(),
             'share_copy'         => true,
@@ -358,7 +359,7 @@ class Settings {
                 : false;
         };
 
-        foreach ( [ 'loop', 'autoplay_start', 'debug_mode', 'allowBodyFallback' ] as $checkbox_key ) {
+        foreach ( [ 'loop', 'autoplay_start', 'debug_mode', 'allowBodyFallback', 'close_on_backdrop' ] as $checkbox_key ) {
             $output[ $checkbox_key ] = $resolve_checkbox_value( $checkbox_key );
         }
 

--- a/ma-galerie-automatique/includes/admin-page-template.php
+++ b/ma-galerie-automatique/includes/admin-page-template.php
@@ -245,6 +245,21 @@ $settings          = wp_parse_args( $sanitized_settings, $defaults );
                             </div>
 
                             <div class="mga-toggle-list__item">
+                                <input type="hidden" name="mga_settings[close_on_backdrop]" value="0" />
+                                <label for="mga_close_on_backdrop">
+                                    <input
+                                        name="mga_settings[close_on_backdrop]"
+                                        type="checkbox"
+                                        id="mga_close_on_backdrop"
+                                        value="1"
+                                        <?php checked( ! empty( $settings['close_on_backdrop'] ), 1 ); ?>
+                                    />
+                                    <span><?php echo esc_html__( 'Fermer sur clic arrière-plan', 'lightbox-jlg' ); ?></span>
+                                </label>
+                                <p class="description"><?php echo esc_html__( "Décochez pour empêcher la fermeture de la visionneuse lorsque l'arrière-plan est cliqué.", 'lightbox-jlg' ); ?></p>
+                            </div>
+
+                            <div class="mga-toggle-list__item">
                                 <input type="hidden" name="mga_settings[show_zoom]" value="0" />
                                 <label for="mga_show_zoom">
                                     <input name="mga_settings[show_zoom]" type="checkbox" id="mga_show_zoom" value="1" <?php checked( ! empty( $settings['show_zoom'] ), 1 ); ?> />


### PR DESCRIPTION
## Summary
- add a "Fermer sur clic arrière-plan" toggle to the gallery settings page
- store the new option with existing settings defaults and sanitization
- respect the toggle when handling global clicks in the slideshow script

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e034bb9f2c832e967cff63576ff974