### PR TITLE
Improve lightbox note accessibility

### DIFF
--- a/ma-galerie-automatique/assets/js/block-editor-preview.js
+++ b/ma-galerie-automatique/assets/js/block-editor-preview.js
@@ -150,7 +150,10 @@
             wrapperProps[ 'data-mga-lightbox-note' ] = noteText;
 
             if ( descriptionId ) {
-                wrapperProps[ 'aria-describedby' ] = descriptionId;
+                var existingDescription = wrapperProps[ 'aria-describedby' ];
+                wrapperProps[ 'aria-describedby' ] = existingDescription
+                    ? ( existingDescription + ' ' + descriptionId ).trim()
+                    : descriptionId;
             } else if ( ! wrapperProps[ 'aria-label' ] ) {
                 wrapperProps[ 'aria-label' ] = noteText;
             }

--- a/ma-galerie-automatique/assets/js/block/index.js
+++ b/ma-galerie-automatique/assets/js/block/index.js
@@ -379,7 +379,10 @@
         blockProps[ 'data-mga-lightbox-note' ] = noteText;
 
         if ( hiddenNoteId ) {
-            blockProps[ 'aria-describedby' ] = hiddenNoteId;
+            var existingDescription = blockProps[ 'aria-describedby' ];
+            blockProps[ 'aria-describedby' ] = existingDescription
+                ? ( existingDescription + ' ' + hiddenNoteId ).trim()
+                : hiddenNoteId;
         } else if ( ! blockProps[ 'aria-label' ] ) {
             blockProps[ 'aria-label' ] = noteText;
         }


### PR DESCRIPTION
## Summary
- preserve existing aria-describedby values when attaching the lightbox note helper
- ensure the lightbox preview wrapper merges its accessible description rather than overwriting other labels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e034b98e14832eb119b49403f18f16