### PR TITLE
Handle media links in dynamic query blocks

### DIFF
--- a/tests/phpunit/EnqueueEligibilityTest.php
+++ b/tests/phpunit/EnqueueEligibilityTest.php
@@ -301,6 +301,32 @@ HTML;
     }
 
     /**
+     * Query Loop blocks with featured images linked to media files should enqueue assets for the lightbox.
+     */
+    public function test_query_loop_featured_image_linked_to_media_triggers_enqueue() {
+        $query_loop_markup = <<<'HTML'
+<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","inherit":true}} -->
+<!-- wp:post-template -->
+<!-- wp:post-featured-image {"isLink":true,"linkDestination":"media"} /-->
+<!-- /wp:post-template -->
+<!-- /wp:query -->
+HTML;
+
+        $post_id = self::factory()->post->create(
+            [
+                'post_content' => $query_loop_markup,
+            ]
+        );
+
+        $this->go_to( get_permalink( $post_id ) );
+
+        $this->assertTrue(
+            $this->detection()->should_enqueue_assets( $post_id ),
+            'Query Loop featured images linking to media files should enqueue assets.'
+        );
+    }
+
+    /**
      * Forcing an enqueue on non singular views without a global WP_Post should not trigger notices.
      */
     public function test_force_enqueue_without_global_post_object() {


### PR DESCRIPTION
## Summary
- expand the default block detection list to cover query loop and post featured image blocks
- enhance media link detection to honour isLink/linkDestination metadata and dynamic bindings
- add PHPUnit coverage for a Query Loop with featured images linked to media files

## Testing
- phpunit --configuration phpunit.xml.dist *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e12d68a230832eb697d7a6e92f390f