### PR TITLE
Preserve stored settings when sanitizing partial updates

### DIFF
--- a/tests/phpunit/SettingsSanitizeTest.php
+++ b/tests/phpunit/SettingsSanitizeTest.php
@@ -197,6 +197,29 @@ class SettingsSanitizeTest extends WP_UnitTestCase {
                     ],
                 ],
             ],
+            'partial_updates_preserve_existing_values' => [
+                [
+                    'thumb_size_mobile' => 60,
+                ],
+                [
+                    'delay'             => 8,
+                    'thumb_size'        => 120,
+                    'thumb_size_mobile' => 55,
+                    'accent_color'      => '#123456',
+                    'bg_opacity'        => 0.65,
+                    'z_index'           => 50,
+                    'background_style'  => 'blur',
+                ],
+                [
+                    'delay'            => 8,
+                    'thumb_size'       => 120,
+                    'thumb_size_mobile'=> 60,
+                    'accent_color'     => '#123456',
+                    'bg_opacity'       => 0.65,
+                    'z_index'          => 50,
+                    'background_style' => 'blur',
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
## Summary
- ensure sanitize_settings falls back to sanitized existing values for missing numeric and color options
- document the partial update behaviour and cover it with a unit test scenario

## Testing
- phpunit --configuration phpunit.xml.dist *(fails: phpunit executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a401babc832e8ad84de4a376a6ae