### PR TITLE
Add tests for gallery thumbnail layouts

### DIFF
--- a/tests/phpunit/SettingsSanitizeTest.php
+++ b/tests/phpunit/SettingsSanitizeTest.php
@@ -98,6 +98,7 @@ class SettingsSanitizeTest extends WP_UnitTestCase {
                     'show_share'      => '1',
                     'share_copy'      => '0',
                     'share_download'  => '',
+                    'thumbs_layout'   => 'left',
                 ],
                 [],
                 [
@@ -108,6 +109,27 @@ class SettingsSanitizeTest extends WP_UnitTestCase {
                     'show_thumbs_mobile' => $defaults['show_thumbs_mobile'],
                     'share_copy'      => false,
                     'share_download'  => false,
+                    'thumbs_layout'   => 'left',
+                ],
+            ],
+            'thumbs_layout_existing_value_is_preserved' => [
+                [],
+                [
+                    'thumbs_layout' => 'hidden',
+                ],
+                [
+                    'thumbs_layout' => 'hidden',
+                ],
+            ],
+            'thumbs_layout_invalid_values_fall_back_to_default' => [
+                [
+                    'thumbs_layout' => 'diagonal',
+                ],
+                [
+                    'thumbs_layout' => 'left',
+                ],
+                [
+                    'thumbs_layout' => $defaults['thumbs_layout'],
                 ],
             ],
             'show_thumbs_mobile_toggle' => [


### PR DESCRIPTION
## Summary
- extend the settings sanitization PHPUnit coverage to include the new `thumbs_layout` options and fallbacks
- add Jest tests that exercise the viewer behaviour for the left and hidden thumbnail layouts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e24e3268ec832eacad1796020d0bc0