### PR TITLE
Validate share channel template protocols

### DIFF
--- a/ma-galerie-automatique/includes/admin-page-template.php
+++ b/ma-galerie-automatique/includes/admin-page-template.php
@@ -423,6 +423,7 @@ $settings          = wp_parse_args( $sanitized_settings, $defaults );
                                                     placeholder="<?php echo esc_attr__( 'https://exemple.com/?u=%url%', 'lightbox-jlg' ); ?>"
                                                 />
                                                 <p class="description"><?php echo esc_html__( 'Placez %url%, %text% ou %title% pour injecter les informations de l’image.', 'lightbox-jlg' ); ?></p>
+                                                <p class="description"><?php echo esc_html__( 'Seules les URL avec un schéma autorisé (http, https, mailto, sms, tel, …) sont acceptées. Les schémas bloqués comme « javascript: » sont remis à zéro.', 'lightbox-jlg' ); ?></p>
                                             </div>
                                             <div class="mga-share-repeater__field">
                                                 <label data-share-id-suffix="icon"><?php echo esc_html__( 'Icône', 'lightbox-jlg' ); ?></label>

--- a/tests/phpunit/SettingsSanitizeTest.php
+++ b/tests/phpunit/SettingsSanitizeTest.php
@@ -15,6 +15,37 @@ class SettingsSanitizeTest extends WP_UnitTestCase {
 
         foreach ( $expected_subset as $key => $expected_value ) {
             $this->assertArrayHasKey( $key, $result, sprintf( 'The %s key should exist in the sanitized settings.', $key ) );
+            if ( 'share_channels' === $key ) {
+                $actual_channels = $this->map_share_channels_by_key( $result[ $key ] );
+
+                foreach ( $expected_value as $channel_key => $channel_expectations ) {
+                    $this->assertArrayHasKey(
+                        $channel_key,
+                        $actual_channels,
+                        sprintf( 'The %s share channel should be present after sanitization.', $channel_key )
+                    );
+
+                    foreach ( $channel_expectations as $field_key => $field_value ) {
+                        $this->assertArrayHasKey(
+                            $field_key,
+                            $actual_channels[ $channel_key ],
+                            sprintf( 'The %s field should exist for the %s share channel.', $field_key, $channel_key )
+                        );
+                        $this->assertSame(
+                            $field_value,
+                            $actual_channels[ $channel_key ][ $field_key ],
+                            sprintf(
+                                'The %s field for the %s share channel did not match the expected value.',
+                                $field_key,
+                                $channel_key
+                            )
+                        );
+                    }
+                }
+
+                continue;
+            }
+
             $this->assertSame( $expected_value, $result[ $key ], sprintf( 'The %s key did not match the expected sanitized value.', $key ) );
         }
     }
@@ -25,9 +56,10 @@ class SettingsSanitizeTest extends WP_UnitTestCase {
      * @return array[]
      */
     public function sanitize_settings_provider() {
-        $defaults          = $this->settings()->get_default_settings();
-        $all_post_types    = get_post_types( [], 'names' );
-        $default_tracked   = array_values( array_intersect( (array) $defaults['tracked_post_types'], $all_post_types ) );
+        $defaults               = $this->settings()->get_default_settings();
+        $default_share_channels = $this->map_share_channels_by_key( $defaults['share_channels'] ?? [] );
+        $all_post_types         = get_post_types( [], 'names' );
+        $default_tracked        = array_values( array_intersect( (array) $defaults['tracked_post_types'], $all_post_types ) );
 
         return [
             'numeric_bounds' => [
@@ -200,21 +232,40 @@ class SettingsSanitizeTest extends WP_UnitTestCase {
                 ],
                 [
                     'share_channels' => [
-                        'facebook' => [
+                        'facebook'  => [
                             'enabled'  => false,
                             'template' => 'https://example.com/?u=%url%',
                         ],
-                        'twitter' => [
+                        'twitter'   => [
                             'enabled'  => true,
-                            'template' => $defaults['share_channels']['twitter']['template'],
+                            'template' => $default_share_channels['twitter']['template'],
                         ],
-                        'linkedin' => [
+                        'linkedin'  => [
                             'enabled'  => false,
                             'template' => 'https://linked.in/share?u=%url%',
                         ],
                         'pinterest' => [
-                            'enabled'  => $defaults['share_channels']['pinterest']['enabled'],
-                            'template' => $defaults['share_channels']['pinterest']['template'],
+                            'enabled'  => $default_share_channels['pinterest']['enabled'],
+                            'template' => $default_share_channels['pinterest']['template'],
+                        ],
+                    ],
+                ],
+            ],
+            'share_channel_template_with_javascript_scheme_is_rejected' => [
+                [
+                    'share_channels' => [
+                        'facebook' => [
+                            'enabled'  => '1',
+                            'template' => 'javascript:alert(%title%)',
+                        ],
+                    ],
+                ],
+                [],
+                [
+                    'share_channels' => [
+                        'facebook' => [
+                            'enabled'  => true,
+                            'template' => $default_share_channels['facebook']['template'],
                         ],
                     ],
                 ],
@@ -245,6 +296,32 @@ class SettingsSanitizeTest extends WP_UnitTestCase {
                 ],
             ],
         ];
+    }
+
+    private function map_share_channels_by_key( array $channels ): array {
+        $mapped = [];
+
+        foreach ( $channels as $index => $channel ) {
+            if ( ! is_array( $channel ) ) {
+                continue;
+            }
+
+            $channel_key = '';
+
+            if ( ! empty( $channel['key'] ) && is_scalar( $channel['key'] ) ) {
+                $channel_key = (string) $channel['key'];
+            } elseif ( is_string( $index ) && '' !== $index ) {
+                $channel_key = $index;
+            }
+
+            if ( '' === $channel_key ) {
+                continue;
+            }
+
+            $mapped[ $channel_key ] = $channel;
+        }
+
+        return $mapped;
     }
 
     private function settings(): \MaGalerieAutomatique\Admin\Settings {


### PR DESCRIPTION
## Summary
- enforce allowed URL schemes when sanitizing share channel templates and fall back to safe defaults
- document allowed link protocols in the admin UI so administrators know what will be accepted
- extend the settings sanitization tests to map share channels by key and cover javascript: templates being rejected

## Testing
- php -l ma-galerie-automatique/includes/Admin/Settings.php
- php -l ma-galerie-automatique/includes/admin-page-template.php
- php -l tests/phpunit/SettingsSanitizeTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e27fd69754832e935d6a90ea7754de