### PR TITLE
Fix share template resolution and add tests

### DIFF
--- a/ma-galerie-automatique/includes/Admin/Settings.php
+++ b/ma-galerie-automatique/includes/Admin/Settings.php
@@ -694,23 +694,43 @@ class Settings {
             }
 
             $template_candidates = [];
+            $template            = '';
+
+            $candidate_template_sanitized = '';
 
             if ( isset( $channel_candidate['template'] ) ) {
-                $candidate_template = sanitize_text_field( (string) $channel_candidate['template'] );
-                $template           = $this->sanitize_share_channel_template( $candidate_template );
+                $candidate_template           = sanitize_text_field( (string) $channel_candidate['template'] );
+                $candidate_template_sanitized = $this->sanitize_share_channel_template( $candidate_template );
+                $template_candidates[]        = $candidate_template_sanitized;
             }
 
-            if ( '' === $template && $existing_for_key && isset( $existing_for_key['template'] ) ) {
-                $existing_template = sanitize_text_field( (string) $existing_for_key['template'] );
-                $template          = $this->sanitize_share_channel_template( $existing_template );
+            $existing_template_sanitized = '';
+
+            if ( $existing_for_key && isset( $existing_for_key['template'] ) ) {
+                $existing_template           = sanitize_text_field( (string) $existing_for_key['template'] );
+                $existing_template_sanitized = $this->sanitize_share_channel_template( $existing_template );
+                $template_candidates[]       = $existing_template_sanitized;
             }
 
-            if ( '' === $template && $defaults_for_key && isset( $defaults_for_key['template'] ) ) {
-                $default_template = sanitize_text_field( (string) $defaults_for_key['template'] );
-                $template         = $this->sanitize_share_channel_template( $default_template );
+            $default_template_sanitized = '';
+
+            if ( $defaults_for_key && isset( $defaults_for_key['template'] ) ) {
+                $default_template           = sanitize_text_field( (string) $defaults_for_key['template'] );
+                $default_template_sanitized = $this->sanitize_share_channel_template( $default_template );
+                $template_candidates[]      = $default_template_sanitized;
             }
 
-            $template = $this->resolve_share_channel_template( $template_candidates );
+            if ( ! empty( $template_candidates ) ) {
+                $template = $this->resolve_share_channel_template( $template_candidates );
+            }
+
+            if ( '' === $template ) {
+                if ( '' !== $default_template_sanitized ) {
+                    $template = $default_template_sanitized;
+                } else {
+                    continue;
+                }
+            }
 
             $enabled_default = $defaults_for_key['enabled'] ?? false;
 

--- a/tests/js/gallery-slideshow.test.js
+++ b/tests/js/gallery-slideshow.test.js
@@ -700,4 +700,55 @@ describe('download button integration', () => {
         const updatedShareButton = viewer.querySelector('#mga-share');
         expect(updatedShareButton).toBeNull();
     });
+
+    it('restores the share control when valid custom share templates are provided', () => {
+        expect(shareButton).not.toBeNull();
+
+        Object.defineProperty(navigator, 'share', {
+            configurable: true,
+            writable: true,
+            value: undefined,
+        });
+
+        window.dispatchEvent(new CustomEvent('mga:share-preferences-change', {
+            detail: {
+                share_channels: {},
+                share_copy: false,
+                share_download: false,
+            },
+        }));
+
+        let refreshedShareButton = viewer.querySelector('#mga-share');
+        expect(refreshedShareButton).toBeNull();
+
+        window.dispatchEvent(new CustomEvent('mga:share-preferences-change', {
+            detail: {
+                share_channels: {
+                    reseau_perso: {
+                        enabled: true,
+                        template: 'https://reseau.example/share?u=%url%',
+                        label: 'Réseau Perso',
+                        icon: 'link',
+                    },
+                },
+                share_copy: false,
+                share_download: false,
+            },
+        }));
+
+        refreshedShareButton = viewer.querySelector('#mga-share');
+        expect(refreshedShareButton).not.toBeNull();
+
+        refreshedShareButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+        const shareModal = document.getElementById('mga-share-modal');
+        expect(shareModal).not.toBeNull();
+        expect(shareModal?.classList.contains('is-visible')).toBe(true);
+
+        const shareOptions = shareModal?.querySelectorAll('.mga-share-option') || [];
+        expect(shareOptions.length).toBeGreaterThan(0);
+
+        const customOption = Array.from(shareOptions).find((option) => option.getAttribute('data-share-key') === 'reseau_perso');
+        expect(customOption).toBeTruthy();
+    });
 });


### PR DESCRIPTION
## Summary
- collect sanitized candidate, existing, and default templates before resolving share channel templates and drop channels without a valid fallback
- expand the settings sanitization test to cover custom share templates and assert no doing_it_wrong warnings are emitted
- add a front-end test confirming the share control returns when valid custom share options are provided

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2b6b562d0832eb905e06c6e41011e