### PR TITLE
Fix caption wrapping and start slideshow at clicked image

### DIFF
--- a/ma-galerie-automatique/assets/css/gallery-slideshow.css
+++ b/ma-galerie-automatique/assets/css/gallery-slideshow.css
@@ -43,6 +43,9 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    flex-wrap: wrap;
+    column-gap: 12px;
+    row-gap: 6px;
     padding: calc(15px + env(safe-area-inset-top, 0px)) 15px 15px 15px;
     box-sizing: border-box;
     color: #fff;
@@ -56,6 +59,8 @@
     text-align: center;
     z-index: 10;
     padding: 5px 20px;
+    order: 3;
+    flex: 1 1 100%;
 }
 .mga-caption {
     margin: 0;
@@ -69,6 +74,8 @@
     display: flex;
     align-items: center;
     gap: var(--mga-toolbar-gap);
+    order: 2;
+    margin-left: auto;
 }
 
 .mga-toolbar-button { position: relative; background: transparent; border: none; color: var(--mga-accent-color, #fff); cursor: pointer; padding: 10px; min-width: 44px; min-height: 44px; display: flex; align-items: center; justify-content: center; border-radius: 50%; transition: background-color 0.2s ease, box-shadow 0.2s ease; line-height: 0; }

--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -451,7 +451,7 @@
         const showFullscreen = normalizeFlag(settings.show_fullscreen, true);
         const showThumbsMobile = normalizeFlag(settings.show_thumbs_mobile, true);
         const closeOnBackdropClick = normalizeFlag(settings.close_on_backdrop, true);
-        const startOnClickedImage = normalizeFlag(settings.start_on_clicked_image, false);
+        const startOnClickedImage = normalizeFlag(settings.start_on_clicked_image, true);
         let shareCopyEnabled = normalizeFlag(settings.share_copy, true);
         let shareDownloadEnabled = normalizeFlag(settings.share_download, true);
         let shareChannels = normalizeShareChannels(settings.share_channels);

--- a/ma-galerie-automatique/includes/Admin/Settings.php
+++ b/ma-galerie-automatique/includes/Admin/Settings.php
@@ -275,7 +275,7 @@ class Settings {
             'bg_opacity'         => 0.95,
             'loop'               => true,
             'autoplay_start'     => false,
-            'start_on_clicked_image' => false,
+            'start_on_clicked_image' => true,
             'background_style'   => 'echo',
             'z_index'            => 99999,
             'debug_mode'         => false,


### PR DESCRIPTION
## Summary
- allow the viewer header to wrap so long captions sit on their own row beneath the toolbar
- default the slideshow to open on the image that was clicked so navigation starts in place

## Testing
- `npm test -- --runTestsByPath tests/js/gallery-slideshow.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68e2fa201b04832e842c81c6d635c4c1