### PR TITLE
Improve settings caching, request guards, and gallery accessibility

### DIFF
--- a/ma-galerie-automatique/includes/Content/Detection.php
+++ b/ma-galerie-automatique/includes/Content/Detection.php
@@ -23,6 +23,10 @@ class Detection {
 
         $force_enqueue = apply_filters( 'mga_force_enqueue', false, $post );
 
+        if ( $this->is_excluded_request_context() && ! $force_enqueue ) {
+            return false;
+        }
+
         if ( ! $post instanceof WP_Post ) {
             return (bool) $force_enqueue;
         }
@@ -71,6 +75,26 @@ class Detection {
         $this->request_detection_cache[ $post->ID ] = $has_linked_images;
 
         return $has_linked_images;
+    }
+
+    private function is_excluded_request_context(): bool {
+        if ( function_exists( 'wp_is_serving_rest_request' ) && wp_is_serving_rest_request() ) {
+            return true;
+        }
+
+        if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+            return true;
+        }
+
+        if ( function_exists( 'is_feed' ) && is_feed() ) {
+            return true;
+        }
+
+        if ( function_exists( 'is_embed' ) && is_embed() ) {
+            return true;
+        }
+
+        return false;
     }
 
     public function get_cached_post_linked_images( WP_Post $post ): ?bool {

--- a/ma-galerie-automatique/includes/Plugin.php
+++ b/ma-galerie-automatique/includes/Plugin.php
@@ -247,6 +247,8 @@ class Plugin {
     public function maybe_purge_detection_cache( $old_value, $value, string $option ): void {
         unset( $option );
 
+        $this->settings->invalidate_settings_cache();
+
         if ( ! is_array( $old_value ) ) {
             $old_value = [];
         }

--- a/tests/phpunit/DetectionSettingsPurgeTest.php
+++ b/tests/phpunit/DetectionSettingsPurgeTest.php
@@ -7,6 +7,12 @@ class DetectionSettingsPurgeTest extends WP_UnitTestCase {
         parent::setUp();
 
         update_option( 'mga_settings', [] );
+
+        $plugin = mga_plugin();
+
+        if ( $plugin instanceof \MaGalerieAutomatique\Plugin ) {
+            $plugin->settings()->invalidate_settings_cache();
+        }
     }
 
     public function test_detection_setting_change_purges_cache() {

--- a/tests/phpunit/EnqueueAssetsTest.php
+++ b/tests/phpunit/EnqueueAssetsTest.php
@@ -8,6 +8,12 @@ class EnqueueAssetsTest extends WP_UnitTestCase {
 
         update_option( 'mga_settings', [] );
 
+        $plugin = mga_plugin();
+
+        if ( $plugin instanceof \MaGalerieAutomatique\Plugin ) {
+            $plugin->settings()->invalidate_settings_cache();
+        }
+
         // Prime the dependency containers so get_data() calls operate on known instances.
         wp_styles();
         wp_scripts();

--- a/tests/phpunit/PostCacheMaintenanceTest.php
+++ b/tests/phpunit/PostCacheMaintenanceTest.php
@@ -503,5 +503,11 @@ class PostCacheMaintenanceTest extends WP_UnitTestCase {
 
         global $wpdb;
         $wpdb->delete( $wpdb->postmeta, [ 'meta_key' => '_mga_has_linked_images' ] );
+
+        $plugin = mga_plugin();
+
+        if ( $plugin instanceof \MaGalerieAutomatique\Plugin ) {
+            $plugin->settings()->invalidate_settings_cache();
+        }
     }
 }

--- a/tests/phpunit/SettingsCacheTest.php
+++ b/tests/phpunit/SettingsCacheTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @group settings
+ */
+class SettingsCacheTest extends WP_UnitTestCase {
+    public function setUp(): void {
+        parent::setUp();
+
+        update_option( 'mga_settings', [] );
+
+        $plugin = mga_plugin();
+
+        if ( $plugin instanceof \MaGalerieAutomatique\Plugin ) {
+            $plugin->settings()->invalidate_settings_cache();
+        }
+    }
+
+    public function tearDown(): void {
+        remove_all_filters( 'pre_option_mga_settings' );
+
+        parent::tearDown();
+    }
+
+    public function test_get_sanitized_settings_uses_cache_until_invalidated() {
+        $plugin   = mga_plugin();
+        $this->assertInstanceOf( \MaGalerieAutomatique\Plugin::class, $plugin );
+
+        $settings = $plugin->settings();
+
+        $calls         = 0;
+        $valueProvider = [ 'delay' => 5 ];
+
+        add_filter(
+            'pre_option_mga_settings',
+            function () use ( &$calls, &$valueProvider ) {
+                $calls++;
+                return $valueProvider;
+            }
+        );
+
+        $first  = $settings->get_sanitized_settings();
+        $second = $settings->get_sanitized_settings();
+
+        $this->assertSame( 1, $calls, 'Subsequent calls should reuse the cached snapshot.' );
+        $this->assertSame( $first, $second, 'Cached settings should be returned without recomputation.' );
+        $this->assertSame( 5, $first['delay'], 'The sanitized value should match the provided option.' );
+
+        $valueProvider = [ 'delay' => 9 ];
+        $settings->invalidate_settings_cache();
+
+        $third = $settings->get_sanitized_settings();
+
+        $this->assertSame( 2, $calls, 'Cache invalidation should trigger a new option read.' );
+        $this->assertSame( 9, $third['delay'], 'Invalidated caches should reflect the latest option snapshot.' );
+    }
+
+    public function test_option_updates_invalidate_cache_automatically() {
+        $plugin   = mga_plugin();
+        $this->assertInstanceOf( \MaGalerieAutomatique\Plugin::class, $plugin );
+
+        $settings = $plugin->settings();
+
+        update_option( 'mga_settings', [ 'delay' => 3 ] );
+        $first = $settings->get_sanitized_settings();
+        $this->assertSame( 3, $first['delay'], 'The cached snapshot should reflect the stored option value.' );
+
+        update_option( 'mga_settings', [ 'delay' => 7 ] );
+        $second = $settings->get_sanitized_settings();
+
+        $this->assertSame( 7, $second['delay'], 'Updating the option should invalidate the cache automatically.' );
+    }
+}

--- a/tests/phpunit/SettingsSanitizeTest.php
+++ b/tests/phpunit/SettingsSanitizeTest.php
@@ -3,6 +3,18 @@
  * @group settings
  */
 class SettingsSanitizeTest extends WP_UnitTestCase {
+    public function setUp(): void {
+        parent::setUp();
+
+        update_option( 'mga_settings', [] );
+
+        $plugin = mga_plugin();
+
+        if ( $plugin instanceof \MaGalerieAutomatique\Plugin ) {
+            $plugin->settings()->invalidate_settings_cache();
+        }
+    }
+
     /**
      * @dataProvider sanitize_settings_provider
      *


### PR DESCRIPTION
## Summary
- cache sanitized settings per site and invalidate the snapshot on blog switches or option updates to avoid repeated sanitization work
- skip expensive detection during feed and REST responses unless explicitly forced, keeping existing behaviour for other contexts and adding unit coverage
- refine gallery controls with clearer autoplay labels plus roving tabindex and keyboard support on thumbnails, along with updated unit tests

## Testing
- npm run test:js

------
https://chatgpt.com/codex/tasks/task_e_68e357190668832e8ffb85bdcfdc12b4