### PR TITLE
Add e2e coverage for starting viewer on clicked image

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Le modèle de la page d’administration se trouve dans `includes/admin-page-tem
 ### Tests E2E
 Les scénarios Playwright (par exemple `tests/e2e/gallery-viewer.spec.ts`) génèrent leurs propres images de test afin d’éviter de versionner des médias binaires. Pour vérifier la lightbox avec vos visuels, déposez simplement les fichiers dans `tests/e2e/assets/` (non suivi par Git). Les formats `png`, `jpg`, `jpeg`, `gif`, `webp` ou `avif` sont pris en charge ; prévoyez au minimum deux images.
 
+- ✅ **Test vital : démarrage sur l’image cliquée** — Le scénario `starts the viewer at the clicked image` vérifie que la visionneuse s’ouvre directement sur la miniature sélectionnée au lieu de revenir au début de la galerie. Cette option est essentielle à l’expérience utilisateur et doit rester fonctionnelle à chaque mise à jour.
+
 ## Hooks et personnalisation
 
 Ces filtres permettent d’adapter le comportement du plugin selon vos besoins.

--- a/tests/e2e/gallery-viewer.spec.ts
+++ b/tests/e2e/gallery-viewer.spec.ts
@@ -272,6 +272,33 @@ test.describe('Gallery viewer', () => {
         }
     });
 
+    test('starts the viewer at the clicked image', async ({ page, requestUtils }) => {
+        const { post, uploads, cleanup } = await createPublishedGalleryPost(
+            requestUtils,
+            'Gallery viewer respects clicked image',
+            { minimumImages: 3 },
+        );
+
+        try {
+            await page.goto(post.link);
+
+            const secondTrigger = page.locator(`a[href="${uploads[1].source_url}"]`).first();
+            await expect(secondTrigger.locator('img')).toBeVisible();
+
+            await secondTrigger.click();
+
+            const viewer = page.locator('#mga-viewer');
+            await expect(viewer).toBeVisible();
+            await expect(page.locator('#mga-counter')).toHaveText(`2 / ${uploads.length}`);
+            await expect(page.locator('#mga-main-wrapper .swiper-slide-active img')).toHaveAttribute(
+                'src',
+                uploads[1].source_url,
+            );
+        } finally {
+            await cleanup();
+        }
+    });
+
     test('closes the viewer when clicking the background overlay', async ({ page, requestUtils }) => {
         const { post, uploads, cleanup } = await createPublishedGalleryPost(
             requestUtils,


### PR DESCRIPTION
## Summary
- add a Playwright scenario that opens the viewer from a non-initial image and checks the active slide
- document the critical regression test in the README to highlight its importance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4461a2238832e8ff7d2c60ae655cd