### PR TITLE
Add persistent detection cache keyed by locale and settings

### DIFF
--- a/ma-galerie-automatique/includes/Plugin.php
+++ b/ma-galerie-automatique/includes/Plugin.php
@@ -265,6 +265,7 @@ class Plugin {
         }
 
         delete_post_meta_by_key( '_mga_has_linked_images' );
+        Detection::bump_global_cache_version();
     }
 
     private function normalize_detection_settings( array $settings ): array {

--- a/ma-galerie-automatique/uninstall.php
+++ b/ma-galerie-automatique/uninstall.php
@@ -15,6 +15,7 @@ if ( is_multisite() ) {
         switch_to_blog( $site_id );
         delete_option( 'mga_settings' );
         delete_option( 'mga_swiper_asset_sources' );
+        delete_option( 'mga_detection_cache_version' );
         delete_post_meta_by_key( '_mga_has_linked_images' );
         restore_current_blog();
     }
@@ -24,4 +25,5 @@ if ( is_multisite() ) {
 
 delete_option( 'mga_settings' );
 delete_option( 'mga_swiper_asset_sources' );
+delete_option( 'mga_detection_cache_version' );
 delete_post_meta_by_key( '_mga_has_linked_images' );

--- a/tests/phpunit/DetectionSettingsPurgeTest.php
+++ b/tests/phpunit/DetectionSettingsPurgeTest.php
@@ -1,4 +1,6 @@
 <?php
+
+use MaGalerieAutomatique\Content\Detection;
 /**
  * @group settings
  */
@@ -13,6 +15,8 @@ class DetectionSettingsPurgeTest extends WP_UnitTestCase {
         if ( $plugin instanceof \MaGalerieAutomatique\Plugin ) {
             $plugin->settings()->invalidate_settings_cache();
         }
+
+        Detection::bump_global_cache_version();
     }
 
     public function test_detection_setting_change_purges_cache() {
@@ -102,5 +106,7 @@ class DetectionSettingsPurgeTest extends WP_UnitTestCase {
         $this->assertSame( $expected, (bool) $meta['has_linked_images'], $message );
         $this->assertArrayHasKey( 'signature', $meta );
         $this->assertNotEmpty( $meta['signature'], 'Cache entries must include a non-empty signature.' );
+        $this->assertArrayHasKey( 'settings_signature', $meta );
+        $this->assertNotEmpty( $meta['settings_signature'], 'Cache entries must store a settings signature.' );
     }
 }

--- a/tests/phpunit/PostCacheMaintenanceTest.php
+++ b/tests/phpunit/PostCacheMaintenanceTest.php
@@ -1,4 +1,6 @@
 <?php
+
+use MaGalerieAutomatique\Content\Detection;
 /**
  * @group cache
  */
@@ -451,6 +453,8 @@ class PostCacheMaintenanceTest extends WP_UnitTestCase {
         $this->assertSame( $expected, (bool) $meta['has_linked_images'], $message ?: 'Unexpected cache flag state.' );
         $this->assertArrayHasKey( 'signature', $meta, 'Cache entries must provide a signature for invalidation.' );
         $this->assertNotEmpty( $meta['signature'], 'Cache entries should expose a non-empty signature.' );
+        $this->assertArrayHasKey( 'settings_signature', $meta, 'Cache entries must include the settings signature snapshot.' );
+        $this->assertNotEmpty( $meta['settings_signature'], 'Settings signatures should be persisted with the cache snapshot.' );
     }
 
     private function detection(): \MaGalerieAutomatique\Content\Detection {
@@ -471,5 +475,7 @@ class PostCacheMaintenanceTest extends WP_UnitTestCase {
         if ( $plugin instanceof \MaGalerieAutomatique\Plugin ) {
             $plugin->settings()->invalidate_settings_cache();
         }
+
+        Detection::bump_global_cache_version();
     }
 }


### PR DESCRIPTION
## Summary
- add a persistent detection cache that stores linked-image results per post, locale, and settings snapshot
- extend detection metadata with a settings signature and ensure cache invalidation bumps the shared version
- update uninstall and PHPUnit coverage to account for the new cache mechanism

## Testing
- php -l ma-galerie-automatique/includes/Content/Detection.php
- php -l tests/phpunit/EnqueueEligibilityTest.php
- php -l tests/phpunit/DetectionSettingsPurgeTest.php
- php -l tests/phpunit/PostCacheMaintenanceTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e57634b974832eba894c75ab90972d