### PR TITLE
Guard DOM parsing when DOM extension is unavailable

### DIFF
--- a/ma-galerie-automatique/includes/Content/Detection.php
+++ b/ma-galerie-automatique/includes/Content/Detection.php
@@ -851,6 +851,10 @@ class Detection {
             return false;
         }
 
+        if ( ! class_exists( 'DOMDocument', false ) ) {
+            return $this->fallback_regex_detects_linked_media( $html );
+        }
+
         $document = new DOMDocument();
         $previous_error_state = libxml_use_internal_errors( true );
 


### PR DESCRIPTION
## Summary
- ensure html_contains_linked_media() falls back to regex detection when DOMDocument is unavailable

## Testing
- php -l ma-galerie-automatique/includes/Content/Detection.php

------
https://chatgpt.com/codex/tasks/task_e_68e57a2644f8832eb94f4664b8ede804