### PR TITLE
Fix safe-area offsets for mobile viewer header

### DIFF
--- a/ma-galerie-automatique/assets/css/gallery-slideshow.css
+++ b/ma-galerie-automatique/assets/css/gallery-slideshow.css
@@ -390,15 +390,15 @@
     }
     /* Correction : on cible bien .mga-main-swiper pour l'affichage mobile en mode portrait */
     .mga-viewer.mga-has-caption .mga-main-swiper {
-        margin-top: calc(
-            var(--mga-header-offset, 110px) +
-            env(safe-area-inset-top, 0px)
+        margin-top: var(
+            --mga-header-offset,
+            calc(110px + env(safe-area-inset-top, 0px))
         );
     }
     .mga-viewer:not(.mga-has-caption) .mga-main-swiper {
-        margin-top: calc(
-            var(--mga-header-offset, 60px) +
-            env(safe-area-inset-top, 0px)
+        margin-top: var(
+            --mga-header-offset,
+            calc(60px + env(safe-area-inset-top, 0px))
         );
     }
     .mga-main-swiper {
@@ -421,15 +421,15 @@
         );
     }
     .mga-viewer.mga-hide-thumbs-mobile.mga-has-caption .mga-main-swiper {
-        margin-top: calc(
-            var(--mga-header-offset, 110px) +
-            env(safe-area-inset-top, 0px)
+        margin-top: var(
+            --mga-header-offset,
+            calc(110px + env(safe-area-inset-top, 0px))
         );
     }
     .mga-viewer.mga-hide-thumbs-mobile:not(.mga-has-caption) .mga-main-swiper {
-        margin-top: calc(
-            var(--mga-header-offset, 60px) +
-            env(safe-area-inset-top, 0px)
+        margin-top: var(
+            --mga-header-offset,
+            calc(60px + env(safe-area-inset-top, 0px))
         );
     }
     .mga-thumbs-swiper {


### PR DESCRIPTION
## Summary
- rely on the runtime-measured header offset for swiper positioning without double-counting the top safe-area inset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e57a2aa268832e8dff138c3ea5a255