### PR TITLE
Follow-up: Ensure persistent cache respects linked image filter

### DIFF
--- a/ma-galerie-automatique/includes/Content/Detection.php
+++ b/ma-galerie-automatique/includes/Content/Detection.php
@@ -121,9 +121,12 @@ class Detection {
         $cached_persistent_result = $this->get_persistent_detection_cache( $post->ID, $snapshot );
 
         if ( null !== $cached_persistent_result ) {
-            $this->request_detection_cache[ $post->ID ] = $cached_persistent_result;
+            $filtered_result = apply_filters( 'mga_post_has_linked_images', $cached_persistent_result, $post );
+            $filtered_result = (bool) $filtered_result;
 
-            return $cached_persistent_result;
+            $this->request_detection_cache[ $post->ID ] = $filtered_result;
+
+            return $filtered_result;
         }
 
         $has_linked_images = $this->get_cached_post_linked_images( $post );


### PR DESCRIPTION
## Summary
- ensure the persistent detection cache still applies the mga_post_has_linked_images filter on cache hits

## Testing
- php -l ma-galerie-automatique/includes/Content/Detection.php

------
https://chatgpt.com/codex/tasks/task_e_68e57af1df98832eb88825c94395b4b1