### PR TITLE
Allow slideshow launch for links opening in new tabs

### DIFF
--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -2948,11 +2948,6 @@
                 return;
             }
 
-            const linkTarget = targetLink.getAttribute('target');
-            if (typeof linkTarget === 'string' && linkTarget.toLowerCase() === '_blank') {
-                return;
-            }
-
             if (targetLink.hasAttribute('download')) {
                 return;
             }


### PR DESCRIPTION
## Summary
- ensure lightbox interception no longer bails out when the clicked image link uses target="_blank"

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e58a2ec3e4832ea3703f49f05d7983