### PR TITLE
Fix Swiper slideshow layout and expose slide visibility metrics

### DIFF
--- a/ma-galerie-automatique/assets/css/gallery-slideshow.css
+++ b/ma-galerie-automatique/assets/css/gallery-slideshow.css
@@ -198,12 +198,21 @@
 .mga-timer-progress { stroke: var(--mga-accent-color, #fff); stroke-linecap: round; stroke-dasharray: 100; stroke-dashoffset: 100; transition: stroke-dashoffset 0.2s linear; }
 
 .mga-main-swiper {
+    position: relative;
     width: 100%;
     height: 75%;
     max-width: 98vw;
+    overflow: hidden;
 }
 
-.mga-main-swiper .swiper-slide { position: relative; display: flex; justify-content: center; align-items: center; overflow: hidden; will-change: transform; }
+.mga-main-swiper .swiper-wrapper {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    box-sizing: content-box;
+}
+
+.mga-main-swiper .swiper-slide { position: relative; display: flex; justify-content: center; align-items: center; overflow: hidden; will-change: transform; flex-shrink: 0; width: 100%; }
 .mga-main-swiper .swiper-zoom-container { width: 100%; height: 100%; }
 .mga-main-swiper .swiper-slide img { max-width: 100%; max-height: 100%; width: auto; height: auto; object-fit: contain; border-radius: 8px; }
 
@@ -247,12 +256,29 @@
 }
 
 .mga-thumbs-swiper {
+    position: relative;
     height: calc(var(--mga-thumb-size-desktop, 90px) + env(safe-area-inset-bottom, 0px));
     box-sizing: border-box;
     padding-bottom: env(safe-area-inset-bottom, 0px);
     padding: 10px 0;
     width: 98%;
     max-width: 1200px;
+    overflow: hidden;
+}
+
+.mga-thumbs-swiper .swiper-wrapper {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    box-sizing: content-box;
+}
+
+.mga-thumbs-swiper.swiper-vertical .swiper-wrapper {
+    flex-direction: column;
+}
+
+.mga-thumbs-swiper:not(.swiper-vertical) .swiper-wrapper {
+    flex-direction: row;
 }
 
 .mga-viewer.mga-thumbs-left {

--- a/ma-galerie-automatique/assets/js/debug.js
+++ b/ma-galerie-automatique/assets/js/debug.js
@@ -141,6 +141,19 @@
         triggerCard.appendChild(triggerValue);
         statsGrid.appendChild(triggerCard);
 
+        const slidesCard = document.createElement('div');
+        slidesCard.style.cssText = 'background: #1c1f23; padding: 6px 8px; border-radius: 4px; grid-column: 1 / -1;';
+        const slidesLabel = document.createElement('strong');
+        slidesLabel.style.cssText = 'display: block; margin-bottom: 4px; color: #ccc;';
+        slidesLabel.textContent = mga__( 'Médias visibles :', 'lightbox-jlg' );
+        const slidesValue = document.createElement('div');
+        slidesValue.id = 'mga-debug-visible-slides';
+        slidesValue.style.cssText = 'font-size: 13px; color: #FFEB3B;';
+        slidesValue.textContent = mga__( 'N/A', 'lightbox-jlg' );
+        slidesCard.appendChild(slidesLabel);
+        slidesCard.appendChild(slidesValue);
+        statsGrid.appendChild(slidesCard);
+
         panel.appendChild(statsGrid);
 
         const forceButton = document.createElement('button');
@@ -292,6 +305,10 @@
         }
     }
 
+    function updateVisibleSlides(text) {
+        updateInfo('mga-debug-visible-slides', text, '#FFEB3B');
+    }
+
     function onForceOpen(callback) {
         if (!ensureActive() || typeof callback !== 'function') {
             return;
@@ -315,6 +332,7 @@
         init,
         log,
         updateInfo,
+        updateVisibleSlides,
         onForceOpen,
         stopTimer,
         restartTimer,

--- a/ma-galerie-automatique/assets/js/gallery-slideshow.js
+++ b/ma-galerie-automatique/assets/js/gallery-slideshow.js
@@ -448,6 +448,7 @@
             init: noop,
             log: noop,
             updateInfo: noop,
+            updateVisibleSlides: noop,
             onForceOpen: noop,
             stopTimer: noop,
             restartTimer: noop,
@@ -1557,6 +1558,94 @@
 
             return new Swiper(container, safeConfig);
         }
+
+        const DEVICE_WIDTH_PRESETS = [
+            { key: 'ultrawide', label: mga__( 'Écran ultralarge', 'lightbox-jlg' ), minWidth: 1600 },
+            { key: 'desktop', label: mga__( 'Bureau', 'lightbox-jlg' ), minWidth: 1200 },
+            { key: 'tablet', label: mga__( 'Tablette', 'lightbox-jlg' ), minWidth: 768 },
+            { key: 'portrait', label: mga__( 'Portrait', 'lightbox-jlg' ), minWidth: 0 },
+        ];
+
+        const isFiniteSlidesValue = (value) => typeof value === 'number' && Number.isFinite(value) && !Number.isNaN(value);
+
+        const resolveSlidesPerViewSetting = (config, viewportWidth) => {
+            if (!config || typeof config !== 'object') {
+                return 1;
+            }
+
+            let resolved = config.slidesPerView;
+            const { breakpoints } = config;
+
+            if (breakpoints && typeof breakpoints === 'object') {
+                const candidates = Object.entries(breakpoints)
+                    .map(([breakpoint, breakpointConfig]) => ({
+                        width: parseFloat(breakpoint),
+                        config: breakpointConfig,
+                    }))
+                    .filter(({ width, config: breakpointConfig }) => (
+                        !Number.isNaN(width) &&
+                        viewportWidth >= width &&
+                        breakpointConfig &&
+                        typeof breakpointConfig === 'object'
+                    ))
+                    .sort((a, b) => a.width - b.width);
+
+                candidates.forEach(({ config: breakpointConfig }) => {
+                    if (Object.prototype.hasOwnProperty.call(breakpointConfig, 'slidesPerView')) {
+                        resolved = breakpointConfig.slidesPerView;
+                    }
+                });
+            }
+
+            if (isFiniteSlidesValue(resolved)) {
+                return Math.max(1, Math.ceil(resolved));
+            }
+
+            if (resolved === 'auto') {
+                return 'auto';
+            }
+
+            return 1;
+        };
+
+        const buildSlidesVisibilitySummary = (config) => DEVICE_WIDTH_PRESETS.map((preset) => ({
+            key: preset.key,
+            label: preset.label,
+            value: resolveSlidesPerViewSetting(config, preset.minWidth),
+        }));
+
+        const reportSlidesVisibility = (swiper, config) => {
+            if (!debug || typeof debug.updateVisibleSlides !== 'function') {
+                return;
+            }
+
+            const snapshot = buildSlidesVisibilitySummary(config);
+            const dynamicValue = swiper && typeof swiper.slidesPerViewDynamic === 'function'
+                ? swiper.slidesPerViewDynamic()
+                : null;
+
+            const formatted = snapshot.map(({ label, value }) => {
+                if (value === 'auto') {
+                    if (isFiniteSlidesValue(dynamicValue)) {
+                        return mgaSprintf(
+                            mga__( '%1$s : auto (~%2$s)', 'lightbox-jlg' ),
+                            label,
+                            Math.max(1, Math.round(dynamicValue))
+                        );
+                    }
+
+                    return mgaSprintf(mga__( '%s : auto', 'lightbox-jlg' ), label);
+                }
+
+                return mgaSprintf(
+                    mga__( '%1$s : %2$s', 'lightbox-jlg' ),
+                    label,
+                    value
+                );
+            }).join(' | ');
+
+            debug.updateVisibleSlides(formatted);
+        };
 
         // --- FONCTIONS UTILITAIRES ---
 
@@ -3750,6 +3839,21 @@
             }
 
             applyTransitionEasing(mainSwiper, sanitizedEasing);
+
+            const emitSlidesVisibilityUpdate = () => {
+                const params = (mainSwiper && mainSwiper.params && typeof mainSwiper.params === 'object')
+                    ? mainSwiper.params
+                    : mainSwiperConfig;
+                reportSlidesVisibility(mainSwiper, params);
+            };
+
+            emitSlidesVisibilityUpdate();
+
+            if (mainSwiper && typeof mainSwiper.on === 'function') {
+                mainSwiper.on('resize', emitSlidesVisibilityUpdate);
+                mainSwiper.on('breakpoint', emitSlidesVisibilityUpdate);
+                mainSwiper.on('slidesLengthChange', emitSlidesVisibilityUpdate);
+            }
 
             const autoplayInstance = mainSwiper.autoplay;
             const hasAutoplayModule = !!(autoplayInstance && typeof autoplayInstance.start === 'function' && typeof autoplayInstance.stop === 'function');


### PR DESCRIPTION
## Summary
- ensure the Swiper containers keep a horizontal layout even when the vendor CSS fails to load, preventing the slideshow from stacking vertically
- surface per-device slide visibility metrics in the debug panel and wire the viewer to report the live counts

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68e58d33769c832ebce510a225fde8da