### PR TITLE
Ajouter l’application de presets graphiques dans l’admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,46 @@ Les scénarios Playwright (par exemple `tests/e2e/gallery-viewer.spec.ts`) gén�
 
 ## Hooks et personnalisation
 
+### Presets graphiques inspirés de bibliothèques UI
+
+Pour gagner du temps lors du maquettage, voici six presets de réglages qui s’inspirent de bibliothèques/UI kits populaires. Chacun s’appuie sur les options natives du plugin : effets, easing, dispositions des miniatures, couleurs d’accent et opacité de fond peuvent être ajustés depuis l’interface d’administration.【F:ma-galerie-automatique/includes/Admin/Settings.php†L271-L406】【F:ma-galerie-automatique/includes/Admin/Settings.php†L422-L504】 Depuis **Réglages → Ma Galerie Automatique**, sélectionnez un preset dans le champ « Preset graphique », cliquez sur **Appliquer ce preset** puis affinez librement chaque option ou revenez aux valeurs par défaut en un clic.【F:ma-galerie-automatique/includes/admin-page-template.php†L20-L73】【F:ma-galerie-automatique/assets/js/admin-script.js†L400-L532】 Adaptez librement les valeurs proposées pour coller à votre direction artistique.
+
+#### Preset « Headless UI » — minimalisme fonctionnel
+- **Effet** : `fade` pour des transitions sobres.【F:ma-galerie-automatique/includes/Admin/Settings.php†L484-L493】
+- **Easing** : `ease-in-out` afin de lisser l’entrée/sortie.【F:ma-galerie-automatique/includes/Admin/Settings.php†L495-L504】
+- **Miniatures** : position `hidden` avec zoom activé pour laisser le focus sur l’image principale.【F:ma-galerie-automatique/includes/Admin/Settings.php†L271-L295】【F:ma-galerie-automatique/includes/Admin/Settings.php†L471-L482】
+- **Arrière-plan** : style `echo` avec opacité 0,92 pour un fondu discret.【F:ma-galerie-automatique/includes/Admin/Settings.php†L271-L406】【F:ma-galerie-automatique/includes/Admin/Settings.php†L461-L469】
+
+#### Preset « Shadcn UI » — sobriété typographique
+- **Effet** : `slide` pour accompagner une mise en page éditoriale.【F:ma-galerie-automatique/includes/Admin/Settings.php†L484-L493】
+- **Easing** : `ease-out` pour un ressenti nerveux mais accessible.【F:ma-galerie-automatique/includes/Admin/Settings.php†L495-L504】
+- **Miniatures** : alignées `left` avec taille desktop 88 px / mobile 64 px pour rappeler les barres latérales modulaires.【F:ma-galerie-automatique/includes/Admin/Settings.php†L271-L406】【F:ma-galerie-automatique/includes/Admin/Settings.php†L471-L482】
+- **Couleur d’accent** : `#0f172a` (ardoise) et opacité 0,85 pour s’harmoniser avec des interfaces sombres.【F:ma-galerie-automatique/includes/Admin/Settings.php†L271-L406】
+
+#### Preset « Radix UI » — accessibilité stricte
+- **Effet** : `slide` avec vitesse 450 ms pour conserver la perception de mouvement tout en respectant les préférences réduites.【F:ma-galerie-automatique/includes/Admin/Settings.php†L271-L406】【F:ma-galerie-automatique/includes/Admin/Settings.php†L484-L504】
+- **Easing** : `linear` afin d’offrir une animation prévisible.【F:ma-galerie-automatique/includes/Admin/Settings.php†L495-L504】
+- **Miniatures** : `bottom`, 96 px desktop / 72 px mobile avec contraste renforcé (`accent_color` `#2563eb`).【F:ma-galerie-automatique/includes/Admin/Settings.php†L271-L406】【F:ma-galerie-automatique/includes/Admin/Settings.php†L471-L482】
+- **Barre d’actions** : conserver zoom, téléchargement et partage pour répondre aux cas d’usage avancés.【F:ma-galerie-automatique/includes/Admin/Settings.php†L271-L296】
+
+#### Preset « Bootstrap » — esthétique corporate
+- **Effet** : `slide` rapide (350 ms) pour refléter la réactivité des composants Bootstrap.【F:ma-galerie-automatique/includes/Admin/Settings.php†L271-L406】【F:ma-galerie-automatique/includes/Admin/Settings.php†L484-L504】
+- **Easing** : `ease` couplé à l’autoplay en pause par défaut (lecture manuelle).【F:ma-galerie-automatique/includes/Admin/Settings.php†L271-L435】【F:ma-galerie-automatique/includes/Admin/Settings.php†L495-L504】
+- **Couleur d’accent** : `#0d6efd`, opacité de fond 0,9 et miniatures `bottom` pour rappeler la hiérarchie visuelle classique.【F:ma-galerie-automatique/includes/Admin/Settings.php†L271-L406】【F:ma-galerie-automatique/includes/Admin/Settings.php†L471-L482】
+- **CTA** : garder le bouton d’appel à l’action visible afin d’encourager les interactions commerciales.【F:ma-galerie-automatique/includes/Admin/Settings.php†L271-L296】
+
+#### Preset « Semantic UI » — équilibre éditorial
+- **Effet** : `coverflow` pour apporter une touche dynamique maîtrisée.【F:ma-galerie-automatique/includes/Admin/Settings.php†L484-L493】
+- **Easing** : `ease-in-out` et délai 5 s pour laisser respirer les visuels.【F:ma-galerie-automatique/includes/Admin/Settings.php†L271-L406】【F:ma-galerie-automatique/includes/Admin/Settings.php†L495-L504】
+- **Miniatures** : `bottom`, 80 px desktop, 60 px mobile, accent `#6435c9` (violet) pour rappeler la palette Semantic.【F:ma-galerie-automatique/includes/Admin/Settings.php†L271-L406】【F:ma-galerie-automatique/includes/Admin/Settings.php†L471-L482】
+- **Fond** : style `blur` pour souligner les transitions tout en conservant la lisibilité des légendes.【F:ma-galerie-automatique/includes/Admin/Settings.php†L271-L406】【F:ma-galerie-automatique/includes/Admin/Settings.php†L461-L469】
+
+#### Preset « Anime.js » — motion design expressif
+- **Effet** : `flip` avec vitesse 520 ms pour un rendu cinétique.【F:ma-galerie-automatique/includes/Admin/Settings.php†L271-L406】【F:ma-galerie-automatique/includes/Admin/Settings.php†L484-L504】
+- **Easing** : `ease-in-out` et autoplay activé pour lancer le storytelling visuel automatiquement.【F:ma-galerie-automatique/includes/Admin/Settings.php†L271-L435】【F:ma-galerie-automatique/includes/Admin/Settings.php†L495-L504】
+- **Couleur d’accent** : gradient néon (ex. `#f97316` en accent principal) et opacité 0,75 pour laisser transparaître les textures de fond.【F:ma-galerie-automatique/includes/Admin/Settings.php†L271-L406】
+- **Miniatures** : `hidden` sur desktop mais visibles sur mobile (`show_thumbs_mobile` vrai) pour maximiser l’espace scénique tout en conservant la navigation tactile.【F:ma-galerie-automatique/includes/Admin/Settings.php†L271-L296】【F:ma-galerie-automatique/includes/Admin/Settings.php†L471-L482】
+
 Ces filtres permettent d’adapter le comportement du plugin selon vos besoins.
 
 ### Quand ajuster les sélecteurs CSS ?

--- a/ma-galerie-automatique/assets/css/admin-style.css
+++ b/ma-galerie-automatique/assets/css/admin-style.css
@@ -275,6 +275,18 @@
     outline: none;
 }
 
+.mga-admin-wrap .mga-style-preset-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.mga-admin-wrap .mga-style-preset-description {
+    margin-top: 8px;
+}
+
 .mga-admin-wrap input[type="range"]::-webkit-slider-thumb {
     -webkit-appearance: none;
     appearance: none;

--- a/ma-galerie-automatique/assets/js/admin-script.js
+++ b/ma-galerie-automatique/assets/js/admin-script.js
@@ -391,6 +391,290 @@
             }
         }
 
+        const stylePresetExport = global.mgaStylePresets && typeof global.mgaStylePresets === 'object'
+            ? global.mgaStylePresets
+            : {};
+        const stylePresets = stylePresetExport.presets && typeof stylePresetExport.presets === 'object'
+            ? stylePresetExport.presets
+            : {};
+        const presetSelect = doc.getElementById('mga_style_preset');
+        const applyPresetButton = doc.querySelector('[data-mga-apply-style-preset]');
+        const resetPresetButton = doc.querySelector('[data-mga-reset-style-preset]');
+        const presetDescription = doc.querySelector('[data-mga-style-preset-description]');
+        let isApplyingPreset = false;
+
+        const maybeDispatchEvent = (element, eventType) => {
+            if (!element || typeof element.dispatchEvent !== 'function') {
+                return;
+            }
+
+            try {
+                element.dispatchEvent(new Event(eventType, { bubbles: true }));
+            } catch (error) {
+                if (typeof doc.createEvent === 'function') {
+                    try {
+                        const fallbackEvent = doc.createEvent('Event');
+                        fallbackEvent.initEvent(eventType, true, true);
+                        element.dispatchEvent(fallbackEvent);
+                    } catch (fallbackError) {
+                        // Ignore unsupported event creation paths.
+                    }
+                }
+            }
+        };
+
+        const setNumericInputValue = (id, value) => {
+            const input = doc.getElementById(id);
+
+            if (!input) {
+                return;
+            }
+
+            input.value = value;
+            maybeDispatchEvent(input, 'input');
+            maybeDispatchEvent(input, 'change');
+        };
+
+        const setRangeInputValue = setNumericInputValue;
+
+        const setSelectValue = (id, value) => {
+            const select = doc.getElementById(id);
+
+            if (!select) {
+                return;
+            }
+
+            select.value = value;
+            maybeDispatchEvent(select, 'change');
+        };
+
+        const setCheckboxValue = (id, value) => {
+            const checkbox = doc.getElementById(id);
+
+            if (!checkbox) {
+                return;
+            }
+
+            checkbox.checked = Boolean(value);
+            maybeDispatchEvent(checkbox, 'change');
+        };
+
+        const setAccentColorValue = (value) => {
+            if (!accentColorInput) {
+                return;
+            }
+
+            const targetColor = typeof value === 'string' ? value : '';
+            const maybeJQuery = global.jQuery;
+
+            if (maybeJQuery && typeof maybeJQuery.fn === 'object' && typeof maybeJQuery.fn.wpColorPicker === 'function') {
+                const picker = maybeJQuery(accentColorInput);
+
+                if (picker && typeof picker.wpColorPicker === 'function') {
+                    picker.wpColorPicker('color', targetColor);
+                    return;
+                }
+            }
+
+            accentColorInput.value = targetColor;
+            maybeDispatchEvent(accentColorInput, 'change');
+        };
+
+        const applyPresetSettings = (settings) => {
+            if (!settings || typeof settings !== 'object') {
+                return;
+            }
+
+            if (Object.prototype.hasOwnProperty.call(settings, 'delay')) {
+                setNumericInputValue('mga_delay', settings.delay);
+            }
+
+            if (Object.prototype.hasOwnProperty.call(settings, 'speed')) {
+                setNumericInputValue('mga_speed', settings.speed);
+            }
+
+            if (Object.prototype.hasOwnProperty.call(settings, 'effect')) {
+                setSelectValue('mga_effect', settings.effect);
+            }
+
+            if (Object.prototype.hasOwnProperty.call(settings, 'easing')) {
+                setSelectValue('mga_easing', settings.easing);
+            }
+
+            if (Object.prototype.hasOwnProperty.call(settings, 'thumbs_layout')) {
+                setSelectValue('mga_thumbs_layout', settings.thumbs_layout);
+            }
+
+            if (Object.prototype.hasOwnProperty.call(settings, 'thumb_size')) {
+                setRangeInputValue('mga_thumb_size', settings.thumb_size);
+            }
+
+            if (Object.prototype.hasOwnProperty.call(settings, 'thumb_size_mobile')) {
+                setRangeInputValue('mga_thumb_size_mobile', settings.thumb_size_mobile);
+            }
+
+            if (Object.prototype.hasOwnProperty.call(settings, 'show_thumbs_mobile')) {
+                setCheckboxValue('mga_show_thumbs_mobile', settings.show_thumbs_mobile);
+            }
+
+            if (Object.prototype.hasOwnProperty.call(settings, 'accent_color')) {
+                setAccentColorValue(settings.accent_color);
+            }
+
+            if (Object.prototype.hasOwnProperty.call(settings, 'bg_opacity')) {
+                setRangeInputValue('mga_bg_opacity', settings.bg_opacity);
+            }
+
+            if (Object.prototype.hasOwnProperty.call(settings, 'background_style')) {
+                setSelectValue('mga_background_style', settings.background_style);
+            }
+
+            if (Object.prototype.hasOwnProperty.call(settings, 'autoplay_start')) {
+                setCheckboxValue('mga_autoplay_start', settings.autoplay_start);
+            }
+
+            if (Object.prototype.hasOwnProperty.call(settings, 'loop')) {
+                setCheckboxValue('mga_loop', settings.loop);
+            }
+
+            if (Object.prototype.hasOwnProperty.call(settings, 'show_zoom')) {
+                setCheckboxValue('mga_show_zoom', settings.show_zoom);
+            }
+
+            if (Object.prototype.hasOwnProperty.call(settings, 'show_download')) {
+                setCheckboxValue('mga_show_download', settings.show_download);
+            }
+
+            if (Object.prototype.hasOwnProperty.call(settings, 'show_share')) {
+                setCheckboxValue('mga_show_share', settings.show_share);
+            }
+
+            if (Object.prototype.hasOwnProperty.call(settings, 'show_cta')) {
+                setCheckboxValue('mga_show_cta', settings.show_cta);
+            }
+
+            if (Object.prototype.hasOwnProperty.call(settings, 'show_fullscreen')) {
+                setCheckboxValue('mga_show_fullscreen', settings.show_fullscreen);
+            }
+        };
+
+        const updatePresetDescription = () => {
+            if (!presetDescription) {
+                return;
+            }
+
+            const key = presetSelect ? presetSelect.value : '';
+
+            if (key && stylePresets[key] && stylePresets[key].description) {
+                presetDescription.textContent = stylePresets[key].description;
+                return;
+            }
+
+            const customDescription = typeof stylePresetExport.customDescription === 'string'
+                ? stylePresetExport.customDescription
+                : '';
+
+            presetDescription.textContent = customDescription;
+        };
+
+        const markPresetAsCustom = () => {
+            if (isApplyingPreset || !presetSelect) {
+                return;
+            }
+
+            if (presetSelect.value === '') {
+                return;
+            }
+
+            presetSelect.value = '';
+            updatePresetDescription();
+        };
+
+        const registerPresetWatcher = (id) => {
+            const element = doc.getElementById(id);
+
+            if (!element) {
+                return;
+            }
+
+            const eventNames = ['change'];
+
+            if (element.tagName === 'INPUT' && ['text', 'number', 'range'].includes(element.type)) {
+                eventNames.push('input');
+            }
+
+            eventNames.forEach((eventName) => {
+                element.addEventListener(eventName, markPresetAsCustom);
+            });
+        };
+
+        if (presetSelect) {
+            updatePresetDescription();
+            presetSelect.addEventListener('change', updatePresetDescription);
+        }
+
+        if (applyPresetButton) {
+            applyPresetButton.addEventListener('click', (event) => {
+                event.preventDefault();
+
+                if (!presetSelect) {
+                    return;
+                }
+
+                const key = presetSelect.value;
+
+                if (!key || !stylePresets[key]) {
+                    return;
+                }
+
+                isApplyingPreset = true;
+                applyPresetSettings(stylePresets[key].settings || {});
+                isApplyingPreset = false;
+                updatePresetDescription();
+            });
+        }
+
+        if (resetPresetButton) {
+            resetPresetButton.addEventListener('click', (event) => {
+                event.preventDefault();
+
+                const defaults = stylePresetExport.defaults || {};
+
+                if (defaults && typeof defaults === 'object' && Object.keys(defaults).length > 0) {
+                    isApplyingPreset = true;
+                    applyPresetSettings(defaults);
+                    isApplyingPreset = false;
+                }
+
+                if (presetSelect) {
+                    presetSelect.value = '';
+                }
+
+                updatePresetDescription();
+            });
+        }
+
+        [
+            'mga_delay',
+            'mga_speed',
+            'mga_effect',
+            'mga_easing',
+            'mga_thumb_size',
+            'mga_thumb_size_mobile',
+            'mga_thumbs_layout',
+            'mga_accent_color',
+            'mga_bg_opacity',
+            'mga_background_style',
+            'mga_show_thumbs_mobile',
+            'mga_autoplay_start',
+            'mga_loop',
+            'mga_show_zoom',
+            'mga_show_download',
+            'mga_show_share',
+            'mga_show_cta',
+            'mga_show_fullscreen',
+        ].forEach(registerPresetWatcher);
+
         const shareRepeater = doc.querySelector('[data-share-repeater]');
 
         if (shareRepeater) {

--- a/ma-galerie-automatique/includes/Admin/Settings.php
+++ b/ma-galerie-automatique/includes/Admin/Settings.php
@@ -155,6 +155,179 @@ class Settings {
         return $choices;
     }
 
+    public function get_style_presets(): array {
+        $defaults = $this->get_default_settings();
+
+        return [
+            'headless-ui' => [
+                'label'       => __( 'Headless UI — minimalisme fonctionnel', 'lightbox-jlg' ),
+                'description' => __( 'Transitions en fondu, interface épurée et accent discret pour mettre la photo au premier plan.', 'lightbox-jlg' ),
+                'settings'    => [
+                    'delay'              => 5,
+                    'speed'              => 500,
+                    'effect'             => 'fade',
+                    'easing'             => 'ease-in-out',
+                    'thumbs_layout'      => 'hidden',
+                    'thumb_size'         => 90,
+                    'thumb_size_mobile'  => 70,
+                    'show_thumbs_mobile' => false,
+                    'accent_color'       => '#111827',
+                    'bg_opacity'         => 0.92,
+                    'background_style'   => 'echo',
+                ],
+            ],
+            'shadcn-ui'   => [
+                'label'       => __( 'Shadcn UI — sobriété typographique', 'lightbox-jlg' ),
+                'description' => __( 'Mise en page éditoriale avec miniatures latérales et contraste soutenu.', 'lightbox-jlg' ),
+                'settings'    => [
+                    'delay'              => $defaults['delay'],
+                    'speed'              => 550,
+                    'effect'             => 'slide',
+                    'easing'             => 'ease-out',
+                    'thumbs_layout'      => 'left',
+                    'thumb_size'         => 88,
+                    'thumb_size_mobile'  => 64,
+                    'show_thumbs_mobile' => true,
+                    'accent_color'       => '#0f172a',
+                    'bg_opacity'         => 0.85,
+                    'background_style'   => 'echo',
+                ],
+            ],
+            'radix-ui'    => [
+                'label'       => __( 'Radix UI — accessibilité stricte', 'lightbox-jlg' ),
+                'description' => __( 'Animations prévisibles, contraste fort et navigation renforcée.', 'lightbox-jlg' ),
+                'settings'    => [
+                    'delay'              => 5,
+                    'speed'              => 450,
+                    'effect'             => 'slide',
+                    'easing'             => 'linear',
+                    'thumbs_layout'      => 'bottom',
+                    'thumb_size'         => 96,
+                    'thumb_size_mobile'  => 72,
+                    'show_thumbs_mobile' => true,
+                    'accent_color'       => '#2563eb',
+                    'bg_opacity'         => 0.9,
+                    'background_style'   => 'echo',
+                ],
+            ],
+            'bootstrap'   => [
+                'label'       => __( 'Bootstrap — esthétique corporate', 'lightbox-jlg' ),
+                'description' => __( 'Rythme nerveux, CTA visible et couleur de marque inspirée de Bootstrap 5.', 'lightbox-jlg' ),
+                'settings'    => [
+                    'delay'              => $defaults['delay'],
+                    'speed'              => 350,
+                    'effect'             => 'slide',
+                    'easing'             => 'ease',
+                    'thumbs_layout'      => 'bottom',
+                    'thumb_size'         => 90,
+                    'thumb_size_mobile'  => 70,
+                    'show_thumbs_mobile' => true,
+                    'accent_color'       => '#0d6efd',
+                    'bg_opacity'         => 0.9,
+                    'background_style'   => 'texture',
+                ],
+            ],
+            'semantic-ui' => [
+                'label'       => __( 'Semantic UI — équilibre éditorial', 'lightbox-jlg' ),
+                'description' => __( 'Perspective coverflow, palette violette et transitions plus espacées.', 'lightbox-jlg' ),
+                'settings'    => [
+                    'delay'              => 5,
+                    'speed'              => 650,
+                    'effect'             => 'coverflow',
+                    'easing'             => 'ease-in-out',
+                    'thumbs_layout'      => 'bottom',
+                    'thumb_size'         => 80,
+                    'thumb_size_mobile'  => 60,
+                    'show_thumbs_mobile' => true,
+                    'accent_color'       => '#6435c9',
+                    'bg_opacity'         => 0.9,
+                    'background_style'   => 'blur',
+                ],
+            ],
+            'anime-js'    => [
+                'label'       => __( 'Anime.js — motion design expressif', 'lightbox-jlg' ),
+                'description' => __( 'Transitions cinétiques flip, autoplay activé et ambiance néon.', 'lightbox-jlg' ),
+                'settings'    => [
+                    'delay'              => $defaults['delay'],
+                    'speed'              => 520,
+                    'effect'             => 'flip',
+                    'easing'             => 'ease-in-out',
+                    'thumbs_layout'      => 'hidden',
+                    'thumb_size'         => 90,
+                    'thumb_size_mobile'  => 70,
+                    'show_thumbs_mobile' => true,
+                    'accent_color'       => '#f97316',
+                    'bg_opacity'         => 0.75,
+                    'background_style'   => 'texture',
+                    'autoplay_start'     => true,
+                ],
+            ],
+        ];
+    }
+
+    private function normalize_style_preset_settings_for_js( array $settings ): array {
+        $map = [
+            'delay'              => 'int',
+            'speed'              => 'int',
+            'thumb_size'         => 'int',
+            'thumb_size_mobile'  => 'int',
+            'bg_opacity'         => 'float',
+            'accent_color'       => 'color',
+            'thumbs_layout'      => [ 'bottom', 'left', 'hidden' ],
+            'background_style'   => [ 'echo', 'texture', 'blur' ],
+            'effect'             => [ 'slide', 'fade', 'cube', 'coverflow', 'flip' ],
+            'easing'             => [ 'ease', 'ease-in', 'ease-out', 'ease-in-out', 'linear' ],
+            'show_thumbs_mobile' => 'bool',
+            'autoplay_start'     => 'bool',
+            'loop'               => 'bool',
+            'show_zoom'          => 'bool',
+            'show_download'      => 'bool',
+            'show_share'         => 'bool',
+            'show_cta'           => 'bool',
+            'show_fullscreen'    => 'bool',
+        ];
+
+        $normalized = [];
+
+        foreach ( $map as $key => $type ) {
+            if ( ! array_key_exists( $key, $settings ) ) {
+                continue;
+            }
+
+            $value = $settings[ $key ];
+
+            switch ( $type ) {
+                case 'int':
+                    $normalized[ $key ] = (int) $value;
+                    break;
+                case 'float':
+                    $normalized[ $key ] = round( (float) $value, 2 );
+                    break;
+                case 'bool':
+                    $normalized[ $key ] = (bool) $value;
+                    break;
+                case 'color':
+                    $color = sanitize_hex_color( (string) $value );
+
+                    if ( $color ) {
+                        $normalized[ $key ] = $color;
+                    }
+                    break;
+                default:
+                    if ( is_array( $type ) ) {
+                        $candidate = is_string( $value ) ? strtolower( $value ) : '';
+
+                        if ( in_array( $candidate, $type, true ) ) {
+                            $normalized[ $key ] = $candidate;
+                        }
+                    }
+                    break;
+            }
+        }
+
+        return $normalized;
+    }
+
     private function get_default_share_channels(): array {
         $catalog = $this->get_share_channel_catalog();
 
@@ -251,6 +424,40 @@ class Settings {
         wp_enqueue_script( 'mga-focus-utils' );
         wp_enqueue_script( 'mga-admin-script' );
 
+        $style_presets_for_js = [];
+
+        foreach ( $this->get_style_presets() as $preset_key => $preset_definition ) {
+            $sanitized_key = sanitize_key( (string) $preset_key );
+
+            if ( '' === $sanitized_key ) {
+                continue;
+            }
+
+            $style_presets_for_js[ $sanitized_key ] = [
+                'label'       => isset( $preset_definition['label'] )
+                    ? (string) $preset_definition['label']
+                    : ucwords( str_replace( '-', ' ', $sanitized_key ) ),
+                'description' => isset( $preset_definition['description'] )
+                    ? (string) $preset_definition['description']
+                    : '',
+                'settings'    => $this->normalize_style_preset_settings_for_js(
+                    isset( $preset_definition['settings'] ) && is_array( $preset_definition['settings'] )
+                        ? $preset_definition['settings']
+                        : []
+                ),
+            ];
+        }
+
+        wp_localize_script(
+            'mga-admin-script',
+            'mgaStylePresets',
+            [
+                'presets'           => $style_presets_for_js,
+                'customDescription' => __( 'Réglages personnalisés actifs.', 'lightbox-jlg' ),
+                'defaults'          => $this->normalize_style_preset_settings_for_js( $this->get_default_settings() ),
+            ]
+        );
+
         if ( $this->plugin->languages_directory_exists() ) {
             wp_set_script_translations( 'mga-admin-script', 'lightbox-jlg', $this->plugin->get_languages_path() );
         }
@@ -295,6 +502,7 @@ class Settings {
             'share_channels'     => $this->get_default_share_channels(),
             'share_copy'         => true,
             'share_download'     => true,
+            'style_preset'       => '',
             'groupAttribute'     => 'data-mga-gallery',
             'contentSelectors'   => [],
             'allowBodyFallback'  => false,
@@ -466,6 +674,26 @@ class Settings {
             $output['background_style'] = $existing_settings['background_style'];
         } else {
             $output['background_style'] = $defaults['background_style'];
+        }
+
+        $style_presets          = $this->get_style_presets();
+        $allowed_preset_keys    = array_keys( $style_presets );
+        $resolve_style_preset   = static function ( $value ) use ( $allowed_preset_keys ) {
+            $candidate = sanitize_key( (string) $value );
+
+            if ( '' === $candidate ) {
+                return '';
+            }
+
+            return in_array( $candidate, $allowed_preset_keys, true ) ? $candidate : '';
+        };
+
+        if ( array_key_exists( 'style_preset', $input ) ) {
+            $output['style_preset'] = $resolve_style_preset( $input['style_preset'] );
+        } elseif ( isset( $existing_settings['style_preset'] ) ) {
+            $output['style_preset'] = $resolve_style_preset( $existing_settings['style_preset'] );
+        } else {
+            $output['style_preset'] = $resolve_style_preset( $defaults['style_preset'] ?? '' );
         }
 
         $allowed_thumb_layouts = [ 'bottom', 'left', 'hidden' ];

--- a/ma-galerie-automatique/includes/admin-page-template.php
+++ b/ma-galerie-automatique/includes/admin-page-template.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Sécurité
 $defaults          = mga_get_default_settings();
 $sanitized_settings = mga_sanitize_settings( $settings, $settings );
 $settings          = wp_parse_args( $sanitized_settings, $defaults );
+$style_presets     = mga_get_style_presets();
 
 ?>
 <div class="wrap mga-admin-wrap">
@@ -68,6 +69,39 @@ $settings          = wp_parse_args( $sanitized_settings, $defaults );
                     <td>
                         <input name="mga_settings[delay]" type="number" id="mga_delay" value="<?php echo esc_attr( $settings['delay'] ); ?>" min="1" max="30" class="small-text" /> <?php echo esc_html__( 'secondes', 'lightbox-jlg' ); ?>
                         <p class="description"><?php echo esc_html__( "Durée d'affichage de chaque image en mode lecture automatique.", 'lightbox-jlg' ); ?></p>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mga_style_preset"><?php echo esc_html__( 'Preset graphique', 'lightbox-jlg' ); ?></label></th>
+                    <td>
+                        <select
+                            name="mga_settings[style_preset]"
+                            id="mga_style_preset"
+                            aria-describedby="mga_style_preset_help mga_style_preset_description"
+                        >
+                            <option value="" <?php selected( $settings['style_preset'], '' ); ?>><?php echo esc_html__( 'Aucun (personnalisé)', 'lightbox-jlg' ); ?></option>
+                            <?php foreach ( $style_presets as $preset_key => $preset_definition ) :
+                                $sanitized_key = sanitize_key( (string) $preset_key );
+
+                                if ( '' === $sanitized_key ) {
+                                    continue;
+                                }
+
+                                $label = isset( $preset_definition['label'] ) && '' !== trim( (string) $preset_definition['label'] )
+                                    ? $preset_definition['label']
+                                    : ucwords( str_replace( '-', ' ', $sanitized_key ) );
+                                ?>
+                                <option value="<?php echo esc_attr( $sanitized_key ); ?>" <?php selected( $settings['style_preset'], $sanitized_key ); ?>>
+                                    <?php echo esc_html( $label ); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                        <p class="description" id="mga_style_preset_help"><?php echo esc_html__( 'Appliquez un ensemble de réglages inspiré de bibliothèques UI populaires. Vous pouvez ensuite ajuster chaque option librement.', 'lightbox-jlg' ); ?></p>
+                        <div class="mga-style-preset-actions">
+                            <button type="button" class="button button-secondary" data-mga-apply-style-preset><?php echo esc_html__( 'Appliquer ce preset', 'lightbox-jlg' ); ?></button>
+                            <button type="button" class="button-link" data-mga-reset-style-preset><?php echo esc_html__( 'Revenir aux valeurs par défaut', 'lightbox-jlg' ); ?></button>
+                        </div>
+                        <p class="description mga-style-preset-description" id="mga_style_preset_description" data-mga-style-preset-description></p>
                     </td>
                 </tr>
                 <tr>

--- a/ma-galerie-automatique/ma-galerie-automatique.php
+++ b/ma-galerie-automatique/ma-galerie-automatique.php
@@ -223,6 +223,12 @@ function mga_get_share_icon_choices(): array {
     return $plugin ? $plugin->settings()->get_share_icon_choices() : [];
 }
 
+function mga_get_style_presets(): array {
+    $plugin = mga_plugin();
+
+    return $plugin ? $plugin->settings()->get_style_presets() : [];
+}
+
 function mga_sanitize_settings( $input, $existing_settings = null ): array {
     $plugin = mga_plugin();
 

--- a/tests/phpunit/SettingsSanitizeTest.php
+++ b/tests/phpunit/SettingsSanitizeTest.php
@@ -384,6 +384,26 @@ class SettingsSanitizeTest extends WP_UnitTestCase {
                     'background_style' => 'blur',
                 ],
             ],
+            'style_preset_known_value' => [
+                [
+                    'style_preset' => 'headless-ui',
+                ],
+                [],
+                [
+                    'style_preset' => 'headless-ui',
+                ],
+            ],
+            'style_preset_unknown_value_resets_to_custom' => [
+                [
+                    'style_preset' => 'does-not-exist',
+                ],
+                [
+                    'style_preset' => 'radix-ui',
+                ],
+                [
+                    'style_preset' => '',
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
## Summary
- définir les presets graphiques prêts à l’emploi et les exposer aux scripts d’administration
- ajouter le sélecteur de preset, ses actions d’application/réinitialisation et les styles associés dans l’interface
- brancher la logique JavaScript d’application/réinitialisation, documenter l’usage et couvrir la sanitation par des tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e62fc2223c832e982291bc9cc5b879