### PR TITLE
Disable share channels lacking templates

### DIFF
--- a/ma-galerie-automatique/includes/Admin/Settings.php
+++ b/ma-galerie-automatique/includes/Admin/Settings.php
@@ -947,12 +947,21 @@ class Settings {
         $defaults_for_key = $defaults_by_key[ $sanitized_key ] ?? [];
         $existing_for_key = $existing_by_key[ $sanitized_key ] ?? [];
 
+        $label    = $this->resolve_share_channel_label( $channel_candidate, $existing_for_key, $defaults_for_key, $sanitized_key );
+        $template = $this->resolve_share_channel_template( $channel_candidate, $existing_for_key, $defaults_for_key );
+        $icon     = $this->resolve_share_channel_icon( $channel_candidate, $existing_for_key, $defaults_for_key, $sanitized_key );
+        $enabled  = $this->resolve_share_channel_enabled( $channel_candidate, $existing_for_key, $defaults_for_key );
+
+        if ( '' === $template ) {
+            $enabled = false;
+        }
+
         return [
             'key'      => $sanitized_key,
-            'label'    => $this->resolve_share_channel_label( $channel_candidate, $existing_for_key, $defaults_for_key, $sanitized_key ),
-            'template' => $this->resolve_share_channel_template( $channel_candidate, $existing_for_key, $defaults_for_key ),
-            'icon'     => $this->resolve_share_channel_icon( $channel_candidate, $existing_for_key, $defaults_for_key, $sanitized_key ),
-            'enabled'  => $this->resolve_share_channel_enabled( $channel_candidate, $existing_for_key, $defaults_for_key ),
+            'label'    => $label,
+            'template' => $template,
+            'icon'     => $icon,
+            'enabled'  => $enabled,
         ];
     }
 

--- a/tests/phpunit/SettingsSanitizeTest.php
+++ b/tests/phpunit/SettingsSanitizeTest.php
@@ -359,6 +359,27 @@ class SettingsSanitizeTest extends WP_UnitTestCase {
                     ],
                 ],
             ],
+            'share_channel_enabled_without_template_is_disabled' => [
+                [
+                    'share_channels' => [
+                        [
+                            'key'      => 'custom-network',
+                            'label'    => 'Custom Network',
+                            'enabled'  => true,
+                            'template' => '   ',
+                        ],
+                    ],
+                ],
+                [],
+                [
+                    'share_channels' => [
+                        'custom-network' => [
+                            'enabled'  => false,
+                            'template' => '',
+                        ],
+                    ],
+                ],
+            ],
             'partial_updates_preserve_existing_values' => [
                 [
                     'thumb_size_mobile' => 60,


### PR DESCRIPTION
## Summary
- force share channel sanitization to disable options that lose their template during validation
- cover the regression with a PHPUnit scenario that ensures blank templates cannot keep a channel enabled

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e67025133c832e9c5fe6ba858dfd96