### PR TITLE
Documente la maintenance multisite et i18n

### DIFF
--- a/AUDIT_COMPARATIF.md
+++ b/AUDIT_COMPARATIF.md
@@ -273,6 +273,20 @@ etc.). Les recommandations sont classées par thématique demandée.
 3. Synchronisation bidirectionnelle avec les galeries WP natives (hooks sur
    `core/gallery`).
 
+## 6. Compatibilité multisite & internationalisation
+
+### Points solides
+- Le cache des réglages est invalidé dès qu’un changement de site survient grâce au hook `switch_blog`, garantissant que chaque blog charge bien sa configuration après bascule.【F:ma-galerie-automatique/includes/Admin/Settings.php†L858-L886】
+- Le fallback de traduction en Base64 permet de livrer une traduction française même lorsque le dossier `languages/` n’est pas disponible sur l’hébergement, assurant un minimum de localisation hors standard WordPress.【F:ma-galerie-automatique/includes/Plugin.php†L68-L120】
+
+### Améliorations recommandées
+- **Tests multisites automatisés** : aucune couverture ne vérifie aujourd’hui que `handle_switch_blog()` purge réellement le cache pour chaque réseau. Ajoutez une batterie de tests PHPUnit simulant les changements de blog afin d’éviter les régressions lors des optimisations de performance.【F:ma-galerie-automatique/includes/Admin/Settings.php†L858-L898】
+- **Gestion avancée des traductions** : le fallback Base64 repose sur un fichier unique (`lightbox-jlg-fr_FR.mo.b64`). Externalisez-le vers un service dédié pour supporter plusieurs locales, gérer la rotation des fichiers temporaires et centraliser les métriques d’échec de chargement.【F:ma-galerie-automatique/includes/Plugin.php†L68-L120】
+
+### Opportunités court terme
+- Instrumentez un log (WP-CLI ou Action Scheduler) pour tracer les rafraîchissements d’assets Swiper et les bascules CDN/local sur chaque site d’un réseau, afin de rassurer les intégrateurs sur la stabilité des déploiements.【F:ma-galerie-automatique/includes/Frontend/Assets.php†L399-L460】
+- Ajoutez une commande WP-CLI qui recompresse automatiquement les fichiers `.mo` en `.b64` et valide leur checksum afin de sécuriser les livraisons continue.【F:ma-galerie-automatique/includes/Plugin.php†L68-L120】
+
 ---
 
 ## Synthèse des écarts et plan d'action

--- a/AUDIT_FONCTIONNALITES.md
+++ b/AUDIT_FONCTIONNALITES.md
@@ -14,6 +14,10 @@
 
 6. **`Plugin::maybe_purge_detection_cache`** – La purge invalide l’ensemble du cache dès qu’un paramètre de détection varie. Des solutions plus fines segmentent par type de contenu ou par site multilingue, et enregistrent des journaux d’invalidation pour aider au diagnostic lors d’un pic de recalcul.【F:ma-galerie-automatique/includes/Plugin.php†L246-L335】
 
+7. **`Settings::handle_switch_blog`** – L’invalidation du cache des réglages repose uniquement sur le hook `switch_blog` et n’est pas couverte par des tests automatisés. Sur un réseau multisite volumineux, une régression casserait la synchronisation des options et pourrait charger les mauvais presets dans le front.【F:ma-galerie-automatique/includes/Admin/Settings.php†L858-L886】
+
+8. **`Frontend\Assets::refresh_swiper_asset_sources`** – La détection et le cache des sources Swiper sont stockés en option simple sans journalisation ni TTL configurable par réseau. Un refactor vers une API modulaire (ex. `wp_register_script` par fonctionnalité) faciliterait les diagnostics CDN/local et la personnalisation par thème.【F:ma-galerie-automatique/includes/Frontend/Assets.php†L399-L460】
+
 ### Feuille de route technique détaillée
 
 | Fonction | Semaine cible | Étapes recommandées | Tests à prévoir | Indicateurs | Risques / mitigation |
@@ -30,5 +34,6 @@
 - **`DetectionSettingsPurgeTest::test_detection_setting_change_purges_cache`** : vérifie que la modification des types suivis supprime bien le meta `_mga_has_linked_images`. Permet de confirmer que les purges s’exécutent lors des changements critiques.【F:tests/phpunit/DetectionSettingsPurgeTest.php†L12-L40】
 - **`DetectionSettingsPurgeTest::test_unrelated_setting_change_preserves_cache`** : garantit qu’un réglage hors périmètre (ex. `debug_mode`) ne vide pas inutilement le cache, ce qui aide à diagnostiquer les invalidations intempestives.【F:tests/phpunit/DetectionSettingsPurgeTest.php†L42-L67】
 - **`DetectionSettingsPurgeTest::test_normalized_selector_equivalence_does_not_trigger_purge`** : assure que les variations de casse/espaces des sélecteurs ne provoquent pas de purge, utile pour isoler les divergences entre interface admin et base de données.【F:tests/phpunit/DetectionSettingsPurgeTest.php†L69-L97】
+- **Couverture multisite** : ajoutez un test PHPUnit dédié à `Settings::handle_switch_blog` pour simuler le changement de blog et vérifier que `invalidate_settings_cache()` supprime bien les entrées correspondantes. Cela sécurisera les optimisations futures du cache en mémoire.【F:ma-galerie-automatique/includes/Admin/Settings.php†L858-L898】
 
 > 💡 Complétez ces tests PHP par une vérification E2E sur une page de démonstration (mode debug actif) afin de capturer les régressions de performance lors des purges massives.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Lightbox - JLG est un plugin WordPress qui transforme automatiquement les galeri
 ## Développement
 Le modèle de la page d’administration se trouve dans `includes/admin-page-template.php` et est chargé automatiquement lors de l’affichage des réglages.
 
+### Suivi technique courant
+- **Cache multisite** : le cache mémoire des réglages est invalidé lors d’un changement de site grâce à `handle_switch_blog()`, mais aucun test automatisé ne couvre encore ce scénario. Planifiez une suite PHPUnit qui vérifie l’invalidation par blog ID pour éviter les régressions sur les réseaux multisites.【F:ma-galerie-automatique/includes/Admin/Settings.php†L858-L898】
+- **Sources Swiper** : le plugin mémorise l’origine des assets Swiper et force un rafraîchissement après une mise à jour, ce qui facilite l’alternance CDN/local. Documentez les impacts en performance et prévoyez un mode debug pour tracer les changements de source lors des déploiements.【F:ma-galerie-automatique/includes/Frontend/Assets.php†L399-L460】
+- **Fallback de traduction** : `load_textdomain()` bascule automatiquement vers un fichier `.mo` encodé en Base64 quand le dossier `languages/` est absent. Ajoutez une procédure de QA pour s’assurer que le fichier encodé est régénéré à chaque livraison et pour surveiller l’usage mémoire du fallback temporaire.【F:ma-galerie-automatique/includes/Plugin.php†L68-L120】
+
 ### Tests E2E
 Les scénarios Playwright (par exemple `tests/e2e/gallery-viewer.spec.ts`) génèrent leurs propres images de test afin d’éviter de versionner des médias binaires. Pour vérifier la lightbox avec vos visuels, déposez simplement les fichiers dans `tests/e2e/assets/` (non suivi par Git). Les formats `png`, `jpg`, `jpeg`, `gif`, `webp` ou `avif` sont pris en charge ; prévoyez au minimum deux images.
 

--- a/ma-galerie-automatique/languages/README.md
+++ b/ma-galerie-automatique/languages/README.md
@@ -14,3 +14,14 @@ Déposez ici les fichiers de traduction (`.po`, `.mo`, `.json`) générés pour 
    base64 lightbox-jlg-fr_FR.mo > lightbox-jlg-fr_FR.mo.b64
    ```
 4. Supprimez le fichier `.mo` compilé (non versionné) et validez le nouveau fichier `.b64`.
+
+## Fallback Base64 utilisé par le plugin
+
+- `Plugin::load_textdomain()` tente d’abord de charger les traductions depuis le dossier `languages/`. S’il est absent, la fonction décode `lightbox-jlg-fr_FR.mo.b64`, écrit un fichier temporaire et l’injecte dans WordPress pour maintenir la localisation minimale.【F:ma-galerie-automatique/includes/Plugin.php†L68-L120】
+- Le fichier encodé doit donc rester synchronisé avec le catalogue `.po` ; tout oubli entraînera un texte obsolète dans ce fallback.
+
+### Contrôle qualité recommandé
+
+1. Après compilation, exécutez `msgattrib --no-obsolete lightbox-jlg-fr_FR.po` pour supprimer les entrées obsolètes avant l’encodage.
+2. Vérifiez que le fichier `.b64` est chargé en staging en renommant temporairement le dossier `languages/` : WordPress doit toujours afficher la traduction française grâce au fallback.【F:ma-galerie-automatique/includes/Plugin.php†L68-L120】
+3. Ajoutez la génération du fichier `.b64` à votre pipeline CI/CD afin d’éviter les écarts entre les traductions et le code livré.


### PR DESCRIPTION
## Summary
- documenter dans le README les points de vigilance techniques liés au cache multisite, aux sources Swiper et au fallback de traduction
- enrichir l'audit comparatif avec une section dédiée à la compatibilité multisite et à l'internationalisation
- compléter l'audit fonctionnel et les consignes de traduction avec les actions à mener autour du hook `switch_blog` et du fichier `.mo` encodé

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e68e7408c8832ebf411efc2349c65a