### PR TITLE
Allow disabling Google SDK requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,20 @@ Lightbox - JLG est un plugin WordPress qui transforme automatiquement les galeri
 ## Installation et activation
 1. Téléchargez ou clonez ce dépôt dans `wp-content/plugins/`.
 2. Depuis le dossier `wp-content/plugins/ma-galerie-automatique/`, exécutez `composer install --no-dev` afin de récupérer le SDK Google et les dépendances PHP du plugin.
+
+   - Si la commande `composer` n’est pas reconnue (cas fréquent sur Windows), installez Composer depuis <https://getcomposer.org/download/> ou utilisez le binaire local : placez-vous dans le dossier du plugin et lancez `php composer.phar install --no-dev` après avoir téléchargé `composer.phar`.
 3. Dans l'administration WordPress, rendez-vous dans **Extensions → Ajouter** puis activez **Lightbox - JLG**.
 4. Accédez aux paramètres via **Réglages → Ma Galerie Automatique**.
 
 Le dossier `vendor/` généré par Composer est ignoré dans Git : pensez à lancer `composer install --no-dev` avant de créer une archive ZIP ou de déployer l'extension pour inclure le SDK Google.
 
 En cas de notice « Le SDK Google est indisponible » dans l'administration, vérifiez que `composer install --no-dev` a bien été exécuté et que WordPress dispose des droits d'écriture nécessaires dans le dossier `vendor/` du plugin.
+
+Si vous n'utilisez pas les fonctionnalités qui reposent sur le SDK Google, vous pouvez également masquer la notice et désactiver cette dépendance en ajoutant le filtre suivant dans un mu-plugin ou le `functions.php` du thème :
+
+```php
+add_filter( 'mga_requires_google_sdk', '__return_false' );
+```
 
 ## Fonctionnalités détaillées
 

--- a/ma-galerie-automatique/includes/Cli/DoctorCommand.php
+++ b/ma-galerie-automatique/includes/Cli/DoctorCommand.php
@@ -91,6 +91,16 @@ class DoctorCommand extends WP_CLI_Command {
     }
 
     private function check_google_sdk(): array {
+        $plugin = $this->require_plugin();
+
+        if ( ! $plugin->requires_google_sdk() ) {
+            return [
+                'name'    => 'SDK Google',
+                'success' => true,
+                'details' => 'Le SDK Google est désactivé via le filtre "mga_requires_google_sdk".',
+            ];
+        }
+
         if ( class_exists( '\\Google\\Client' ) ) {
             return [
                 'name'    => 'SDK Google',

--- a/ma-galerie-automatique/includes/Plugin.php
+++ b/ma-galerie-automatique/includes/Plugin.php
@@ -129,10 +129,18 @@ class Plugin {
         }
     }
 
+    public function requires_google_sdk(): bool {
+        return (bool) apply_filters( 'mga_requires_google_sdk', true, $this );
+    }
+
     public function maybe_show_missing_google_sdk_notice(): void {
         static $displayed = false;
 
         if ( $displayed || ! is_admin() || ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
+            return;
+        }
+
+        if ( ! $this->requires_google_sdk() ) {
             return;
         }
 


### PR DESCRIPTION
## Summary
- add a filter to disable the Google SDK requirement and skip the admin notice when the SDK is intentionally unused
- update the WP-CLI doctor command to report the SDK as disabled when the filter is applied
- document how to hide the notice via `mga_requires_google_sdk`

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923485ec060832e9722bc5b8e9a9628)